### PR TITLE
Update DataPipeline-multiple-StringValue.json

### DIFF
--- a/aws/services/DataPipeline/multiple-StringValue/DataPipeline-multiple-StringValue.json
+++ b/aws/services/DataPipeline/multiple-StringValue/DataPipeline-multiple-StringValue.json
@@ -1,9 +1,5 @@
 { 
-  "Description": "A CloudFormation template which shows how to provide multiple values to one StringValue when creating a DataPipeline definition, 
-  This template is entirely based on the example provided in the DataPipeline documentation here: 
-  http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-emrconfiguration.html
-  Written by Nishant Casey",
-  
+  "Description": "A CloudFormation template which shows how to provide multiple values to one StringValue when creating a DataPipeline definition, This template is entirely based on the example provided in the DataPipeline documentation here: http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-emrconfiguration.html - Written by Nishant Casey",
   "Resources": {
     "DynamoDBInputS3OutputHive": {
       "Type": "AWS::DataPipeline::Pipeline",
@@ -22,11 +18,19 @@
               },
               {
                 "Key": "applications",
-                "StringValue": "['spark', 'hive', 'pig']"
+                "StringValue": "spark"
+              },
+              {
+                "Key": "applications",
+                "StringValue": "hive"
+              },
+              {
+                "Key": "applications",
+                "StringValue": "pig"
               },
               {
                 "Key": "type",
-                "StringValue": "EmrCluster",
+                "StringValue": "EmrCluster"
               },
               {
                 "Key": "configuration",


### PR DESCRIPTION
Updating to make changes to the way in which multiple values are declared. The previous method propagated to DataPipeline API but appeared inaccurate in the DP definition file.