### PR TITLE
explicitly cancel timer

### DIFF
--- a/community/custom_resources/python_custom_resource_helper/crhelper.py
+++ b/community/custom_resources/python_custom_resource_helper/crhelper.py
@@ -138,4 +138,5 @@ def cfn_handler(event, context, create, update, delete, logger, init_failed):
         logger.error(e, exc_info=True)
         send(event, context, "FAILED", responseData, physicalResourceId,
              reason=e, logger=logger)
-        raise
+    finally:
+        t.cancel()


### PR DESCRIPTION
timer continued in future invocations that ran on the same lambda container, explicitly cancelling to prevent that behavior.

Also removed the raise on line 141. When lambda raises an exception Cloudformation retries it's execution twice, resulting in unnecessary invocations.