### PR TITLE
SQS DelaySeconds description seemed off

### DIFF
--- a/aws/services/SQS/SQSStandardQueue.json
+++ b/aws/services/SQS/SQSStandardQueue.json
@@ -3,7 +3,7 @@
   "Description": "Best Practice SQS Standard Queue",
   "Parameters": {
       "DelaySeconds": {
-      "Description": "The Id of the AMI you wish to launch the instance from.",
+      "Description": "The time in seconds that the delivery of all messages in the queue is delayed. You can specify an integer value of 0 to 900 (15 minutes).",
       "Type": "Number",
       "Default": "5"
     },


### PR DESCRIPTION
Based on the [CF Guide to SQS Queues](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html), I updated the description here to:
> The time in seconds that the delivery of all messages in the queue is delayed. You can specify an integer value of 0 to 900 (15 minutes).

I left out `The default value is 0.` since the template specifies a value of 5.

Happy to do whatever else is required to get this updated.