### PR TITLE
Update crhelper.py

### DIFF
--- a/community/custom_resources/python_custom_resource_helper/crhelper.py
+++ b/community/custom_resources/python_custom_resource_helper/crhelper.py
@@ -57,7 +57,14 @@ def send(event, context, responseStatus, responseData, physicalResourceId,
         responseBody['Reason'] = msg
     else:
         responseBody['Reason'] = str(reason)[0:255] + '... ' + msg
-    responseBody['PhysicalResourceId'] = physicalResourceId or event['PhysicalResourceId'] or context.log_stream_name
+        
+    if physicalResourceId:
+        responseBody['PhysicalResourceId'] = physicalResourceId
+    elif 'PhysicalResourceId' in event:
+        responseBody['PhysicalResourceId'] = event['PhysicalResourceId']
+    else:
+        responseBody['PhysicalResourceId'] = context.log_stream_name
+
     responseBody['StackId'] = event['StackId']
     responseBody['RequestId'] = event['RequestId']
     responseBody['LogicalResourceId'] = event['LogicalResourceId']

--- a/community/custom_resources/python_custom_resource_helper/crhelper.py
+++ b/community/custom_resources/python_custom_resource_helper/crhelper.py
@@ -57,7 +57,7 @@ def send(event, context, responseStatus, responseData, physicalResourceId,
         responseBody['Reason'] = msg
     else:
         responseBody['Reason'] = str(reason)[0:255] + '... ' + msg
-    responseBody['PhysicalResourceId'] = physicalResourceId or context.log_stream_name
+    responseBody['PhysicalResourceId'] = physicalResourceId or event['PhysicalResourceId'] or context.log_stream_name
     responseBody['StackId'] = event['StackId']
     responseBody['RequestId'] = event['RequestId']
     responseBody['LogicalResourceId'] = event['LogicalResourceId']


### PR DESCRIPTION
If I am using this helper as intended there is a weird condition with Update requests that cause it not to fail correctly.
An exception thrown from a botched update causes the physical id to be changed to the lambda log stream name. 

Cloudformation sees the new physical resource id and assumes the update required a delete event to clean up the old physical resource id instead of just failing on the failure.