### PR TITLE
Reference ContainerPort rather than hardcoding port 80 in Fargate ECS

### DIFF
--- a/aws/services/ECS/FargateLaunchType/services/private-subnet-private-service.yml
+++ b/aws/services/ECS/FargateLaunchType/services/private-subnet-private-service.yml
@@ -129,7 +129,7 @@ Resources:
       HealthyThresholdCount: 2
       TargetType: ip
       Name: !Ref 'ServiceName'
-      Port: 80
+      Port: !Ref 'ContainerPort'
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId:

--- a/aws/services/ECS/FargateLaunchType/services/private-subnet-public-service.yml
+++ b/aws/services/ECS/FargateLaunchType/services/private-subnet-public-service.yml
@@ -129,7 +129,7 @@ Resources:
       HealthyThresholdCount: 2
       TargetType: ip
       Name: !Ref 'ServiceName'
-      Port: 80
+      Port: !Ref 'ContainerPort'
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId:

--- a/aws/services/ECS/FargateLaunchType/services/public-service.yml
+++ b/aws/services/ECS/FargateLaunchType/services/public-service.yml
@@ -129,7 +129,7 @@ Resources:
       HealthyThresholdCount: 2
       TargetType: ip
       Name: !Ref 'ServiceName'
-      Port: 80
+      Port: !Ref 'ContainerPort'
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId:


### PR DESCRIPTION
Current templates hardcode port 80 in the Target Group for health checks rather than
using the ContainerPort parameter. This causes issues if using Docker images not using standard HTTP