### PR TITLE
Removing unneeded, and unusable public IP address

### DIFF
--- a/aws/services/ECS/FargateLaunchType/services/private-subnet-private-service.yml
+++ b/aws/services/ECS/FargateLaunchType/services/private-subnet-private-service.yml
@@ -99,7 +99,6 @@ Resources:
       DesiredCount: !Ref 'DesiredCount'
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
           SecurityGroups:
             - Fn::ImportValue:
                 !Join [':', [!Ref 'StackName', 'FargateContainerSecurityGroup']]


### PR DESCRIPTION
Removing unneeded, and unusable public IP address for containers launched in the private subnet