### PR TITLE
[ADD] Static WebSite submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "community/solutions/staticwebsite"]
+	path = community/solutions/staticwebsite
+	url = https://github.com/grstavares/AWSStaticWebSiteStack.git


### PR DESCRIPTION
Add new repo in the community/solutions for a StaticWebSite CloudFormation template to be created in AWS. The template creates a S3 bucket for the website, create the bucket for website logs, create a ACM certificate, approve the certificate using CustomResources, Create a Route53 record and a CloudFront Distribution. It also has the option to create a complete Pipeline for continuous deployment based on CodeCommit, CodeBuild and CodePipeline.

The template was tested in sa-east-1 region and it's working fine! As per design in the stack deletion it retains the site and logs bucket but I'm working in let this be a option.