### PR TITLE
Revisions to CloudFormation endpoint signal templates

### DIFF
--- a/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-creationpolicy-no-igw.yaml
+++ b/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-creationpolicy-no-igw.yaml
@@ -124,6 +124,8 @@ Resources:
           Fn::Base64:
             !Sub |
               #!/bin/bash -x
+              date > /tmp/datefile
+              cat /tmp/datefile
               # Signal the status from instance
               /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource PrivateInstance --region ${AWS::Region}
 

--- a/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-creationpolicy-no-igw.yaml
+++ b/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-creationpolicy-no-igw.yaml
@@ -30,10 +30,6 @@ Parameters:
         Default: 10.192.21.0/24
         AllowedPattern: '((\d{1,3})\.){3}\d{1,3}/\d{1,2}'
 
-    KeyName:
-        Description: Key pair for EC2 access
-        Type: AWS::EC2::KeyPair::KeyName
-
     LinuxAMI:
         Description: Managed AMI ID for Amazon Linux
         Type : 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
@@ -115,41 +111,15 @@ Resources:
             RouteTableId: !Ref PrivateRouteTable2
             SubnetId: !Ref PrivateSubnet2
 
-    RootRole:
-      Type: "AWS::IAM::Role"
-      Properties:
-        AssumeRolePolicyDocument:
-          Version: "2012-10-17"
-          Statement:
-            -
-              Effect: "Allow"
-              Principal:
-                Service:
-                  - "ec2.amazonaws.com"
-              Action:
-                - "sts:AssumeRole"
-        Path: "/"
-        Policies:
-          -
-            PolicyName: "root"
-            PolicyDocument:
-              Version: "2012-10-17"
-              Statement:
-                -
-                  Effect: "Allow"
-                  Action: "*"
-                  Resource: "*"
-
     PrivateInstance:
+      DependsOn: CfnEndpoint
       Type: AWS::EC2::Instance
       Properties:
-        KeyName: !Ref KeyName
         InstanceType: t3.micro
         SecurityGroupIds:
         - !Ref PrivateSG
         SubnetId: !Ref PrivateSubnet1
         ImageId: !Ref LinuxAMI
-        IamInstanceProfile: !Ref PrivateProfile
         UserData:
           Fn::Base64:
             !Sub |
@@ -181,13 +151,6 @@ Resources:
           -
             Key: Name
             Value: PrivateSG
-
-    PrivateProfile:
-      Type: AWS::IAM::InstanceProfile
-      Properties:
-        Path: "/"
-        Roles:
-          - !Ref RootRole
 
     EndpointSG:
       Type: AWS::EC2::SecurityGroup

--- a/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-creationpolicy.yaml
+++ b/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-creationpolicy.yaml
@@ -259,7 +259,7 @@ Resources:
       Type: AWS::EC2::Instance
       Properties:
         KeyName: !Ref KeyName
-        InstanceType: t3.micro
+        InstanceType: t2.micro
         SecurityGroupIds:
         - !Ref PrivateSG
         SubnetId: !Ref PrivateSubnet1
@@ -269,6 +269,8 @@ Resources:
           Fn::Base64:
             !Sub |
               #!/bin/bash -x
+              date > /tmp/datefile
+              cat /tmp/datefile
               # Signal the status from instance
               /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource PrivateInstance --region ${AWS::Region}
 

--- a/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-creationpolicy.yaml
+++ b/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-creationpolicy.yaml
@@ -213,7 +213,7 @@ Resources:
               Statement:
                 -
                   Effect: "Allow"
-                  Action: "*"
+                  Action: "cloudformation:*"
                   Resource: "*"
 
     BastionInstance:
@@ -255,6 +255,7 @@ Resources:
           - !Ref RootRole
 
     PrivateInstance:
+      DependsOn: CfnEndpoint
       Type: AWS::EC2::Instance
       Properties:
         KeyName: !Ref KeyName

--- a/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-waitcondition-no-igw.yaml
+++ b/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-waitcondition-no-igw.yaml
@@ -30,10 +30,6 @@ Parameters:
         Default: 10.192.21.0/24
         AllowedPattern: '((\d{1,3})\.){3}\d{1,3}/\d{1,2}'
 
-    KeyName:
-        Description: Key pair for EC2 access
-        Type: AWS::EC2::KeyPair::KeyName
-
     LinuxAMI:
         Description: Managed AMI ID for Amazon Linux
         Type : 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
@@ -138,41 +134,15 @@ Resources:
             RouteTableId: !Ref PrivateRouteTable2
             SubnetId: !Ref PrivateSubnet2
 
-    RootRole:
-      Type: "AWS::IAM::Role"
-      Properties:
-        AssumeRolePolicyDocument:
-          Version: "2012-10-17"
-          Statement:
-            -
-              Effect: "Allow"
-              Principal:
-                Service:
-                  - "ec2.amazonaws.com"
-              Action:
-                - "sts:AssumeRole"
-        Path: "/"
-        Policies:
-          -
-            PolicyName: "root"
-            PolicyDocument:
-              Version: "2012-10-17"
-              Statement:
-                -
-                  Effect: "Allow"
-                  Action: "*"
-                  Resource: "*"
-
     PrivateInstance:
+      DependsOn: CfnEndpoint
       Type: AWS::EC2::Instance
       Properties:
-        KeyName: !Ref KeyName
         InstanceType: t3.micro
         SecurityGroupIds:
         - !Ref PrivateSG
         SubnetId: !Ref PrivateSubnet1
         ImageId: !Ref LinuxAMI
-        IamInstanceProfile: !Ref PrivateProfile
         UserData:
           Fn::Base64:
             !Sub |
@@ -200,13 +170,6 @@ Resources:
           -
             Key: Name
             Value: PrivateSG
-
-    PrivateProfile:
-      Type: AWS::IAM::InstanceProfile
-      Properties:
-        Path: "/"
-        Roles:
-          - !Ref RootRole
 
     EndpointSG:
       Type: AWS::EC2::SecurityGroup

--- a/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-waitcondition-no-igw.yaml
+++ b/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-waitcondition-no-igw.yaml
@@ -78,8 +78,7 @@ Resources:
               Action:
                 - "s3:PutObject"
               Resource:
-                - !Sub "arn:aws:s3:::cloudformation-waitcondition-${AWS::Region}/*"
-                - !Sub "arn:aws:s3:::cloudformation-custom-resource-response-${AWS::Region}/*"
+                - !Sub "arn:${AWS::Partition}:s3:::cloudformation-waitcondition-${AWS::Region}/*"
         RouteTableIds:
           - !Ref PrivateRouteTable1
           - !Ref PrivateRouteTable2
@@ -147,6 +146,8 @@ Resources:
           Fn::Base64:
             !Sub |
               #!/bin/bash -x
+              date > /tmp/datefile
+              cat /tmp/datefile
               # Signal the status from instance
               /opt/aws/bin/cfn-signal -e $? -d "This was all private." -r "Build Process Complete" '${PrivateWaitHandle}'
 
@@ -191,6 +192,7 @@ Resources:
       Type: AWS::CloudFormation::WaitConditionHandle
 
     PrivateWaitCondition:
+      DependsOn: PrivateInstance
       Type: AWS::CloudFormation::WaitCondition
       Properties:
         Handle: !Ref PrivateWaitHandle

--- a/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-waitcondition.yaml
+++ b/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-waitcondition.yaml
@@ -108,8 +108,7 @@ Resources:
               Action:
                 - "s3:PutObject"
               Resource:
-                - !Sub "arn:aws:s3:::cloudformation-waitcondition-${AWS::Region}/*"
-                - !Sub "arn:aws:s3:::cloudformation-custom-resource-response-${AWS::Region}/*"
+                - !Sub "arn:${AWS::Partition}:s3:::cloudformation-waitcondition-${AWS::Region}/*"
         RouteTableIds:
           - !Ref PrivateRouteTable1
           - !Ref PrivateRouteTable2
@@ -282,7 +281,7 @@ Resources:
       Type: AWS::EC2::Instance
       Properties:
         KeyName: !Ref KeyName
-        InstanceType: t3.micro
+        InstanceType: t2.micro
         SecurityGroupIds:
         - !Ref PrivateSG
         SubnetId: !Ref PrivateSubnet1
@@ -292,6 +291,8 @@ Resources:
           Fn::Base64:
             !Sub |
               #!/bin/bash -x
+              date > /tmp/datefile
+              cat /tmp/datefile
               # Signal the status from instance
               /opt/aws/bin/cfn-signal -e $? -d "This was all private." -r "Build Process Complete" '${PrivateWaitHandle}'
 
@@ -343,6 +344,7 @@ Resources:
       Type: AWS::CloudFormation::WaitConditionHandle
 
     PrivateWaitCondition:
+      DependsOn: PrivateInstance
       Type: AWS::CloudFormation::WaitCondition
       Properties:
         Handle: !Ref PrivateWaitHandle

--- a/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-waitcondition.yaml
+++ b/aws/solutions/CloudFormationEndpointSignals/cfn-endpoint-waitcondition.yaml
@@ -236,7 +236,7 @@ Resources:
               Statement:
                 -
                   Effect: "Allow"
-                  Action: "*"
+                  Action: "cloudformation:*"
                   Resource: "*"
 
     BastionInstance:
@@ -278,6 +278,7 @@ Resources:
           - !Ref RootRole
 
     PrivateInstance:
+      DependsOn: CfnEndpoint
       Type: AWS::EC2::Instance
       Properties:
         KeyName: !Ref KeyName


### PR DESCRIPTION
* Removed unneeded permissions from instance profile role. 
* Removed unneeded keys from no-IGW instance templates.
* Modified templates to use AWS::Partition for defining the S3 endpoints.
* Added some "busy work" for the private instances to do before signaling.