### PR TITLE
Support optional IAM role name and path

### DIFF
--- a/aws/solutions/StackSetsResource/README.md
+++ b/aws/solutions/StackSetsResource/README.md
@@ -29,6 +29,16 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_IAM
 ```
 
+Alternatively, if you'd like to override one or more of the function stack template parameters:
+
+```
+aws cloudformation deploy \
+  --template-file Templates/packaged-stackset-function-template.yaml \
+  --stack-name StackSetCustomResource \
+  --parameter-overrides RoleName=custom-resource-stacksets RolePath=/company/ \
+  --capabilities CAPABILITY_IAM
+```
+
 CloudFormation will package up the python files, upload them to your S3 bucket, create the lambda function with appropriate permissions and export the Lambda function ARN as `StackSetCustomResource` for use in other stacks.
 
 

--- a/aws/solutions/StackSetsResource/Templates/stackset-function-template.yaml
+++ b/aws/solutions/StackSetsResource/Templates/stackset-function-template.yaml
@@ -1,15 +1,31 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
+
 Description: "Deploy required components for StackSet custom resources in this region.  Lambda ARN is exported as StackSetCustomResource"
+
 Parameters:
   ModuleName:
     Type: String
     Default: "lambda_function"
 
+  RoleName:
+    Type: String
+    Default: ""
+
+  RolePath:
+    Type: String
+    Default: ""
+
+Conditions:
+  UseRoleName: !Not [!Equals [!Ref RoleName, ""]]
+  UseRolePath: !Not [!Equals [!Ref RolePath, ""]]
+
 Resources:
   StackSetResourceRole:
     Type: AWS::IAM::Role
     Properties:
+        RoleName: !If [UseRoleName, !Ref RoleName, !Ref "AWS::NoValue"]
+        Path: !If [UseRolePath, !Ref RolePath, "/"]
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:
@@ -17,7 +33,6 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
-        Path: "/"
         Policies:
           -
             PolicyName: "IAMPassRolePermissions"
@@ -82,6 +97,7 @@ Resources:
     Properties:
       LogGroupName: !Sub '/aws/lambda/${StackSetResourceFunction}'
       RetentionInDays: 7
+
 Outputs:
   StackSetFunctionArn:
     Description: "Resource ARN for the StackSetCustom resource Lambda function"


### PR DESCRIPTION
Title says it all.  We have a customer who would like to ensure that all roles adhere to their naming standards and that custom paths are used for IAM resources where feasible.