### PR TITLE
Upgrading the ECS EC2 clusters to Amazon Linux 2

### DIFF
--- a/aws/services/ECS/EC2LaunchType/clusters/private-vpc.yml
+++ b/aws/services/ECS/EC2LaunchType/clusters/private-vpc.yml
@@ -18,7 +18,7 @@ Parameters:
   ECSAMI:
     Description: AMI ID
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id
+    Default: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
   InstanceType:
     Description: EC2 instance type
     Type: String

--- a/aws/services/ECS/EC2LaunchType/clusters/public-vpc.yml
+++ b/aws/services/ECS/EC2LaunchType/clusters/public-vpc.yml
@@ -15,7 +15,7 @@ Parameters:
   ECSAMI:
     Description: AMI ID
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id
+    Default: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
   InstanceType:
     Description: EC2 instance type
     Type: String


### PR DESCRIPTION
This upgrades the default AMI used for an EC2 cluster orchestrated by ECS from Amazon Linux 1 to Amazon Linux 2