### PR TITLE
Stacksetresource lint

### DIFF
--- a/aws/solutions/StackSetsResource/FunctionCode/crhelper.py
+++ b/aws/solutions/StackSetsResource/FunctionCode/crhelper.py
@@ -110,7 +110,7 @@ def cfn_handler(event, context, create, update, delete, logger, init_failed):
     logger.debug("EVENT: {}".format(event))
     # handle init failures
     if init_failed:
-        send(event, context, "FAILED", response_data, physical_resource_id, logger=logger,  reason=init_failed)
+        send(event, context, "FAILED", response_data, physical_resource_id, init_failed, logger=logger)
         raise Exception('FAILED')
 
     # Setup timer to catch timeouts

--- a/aws/solutions/StackSetsResource/FunctionCode/crhelper.py
+++ b/aws/solutions/StackSetsResource/FunctionCode/crhelper.py
@@ -1,24 +1,29 @@
-###################################################################################################
-#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-####
-#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
-#### except in compliance with the License. A copy of the License is located at
-####
-####     http://aws.amazon.com/apache2.0/
-####
-#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
-#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#### License for the specific language governing permissions and limitations under the License.
-###################################################################################################
+# -*- coding: utf-8 -*-
+#
+# crhelper.py
+#
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##################################################################################################
 
 from __future__ import print_function
-import traceback
+
+import json
 import logging
 import threading
-from time import sleep
-from datetime import datetime
+
 from botocore.vendored import requests
-import json
 
 
 def log_config(event, loglevel=None, botolevel=None):
@@ -28,9 +33,9 @@ def log_config(event, loglevel=None, botolevel=None):
         if 'botolevel' in event['ResourceProperties'] and not botolevel:
             loglevel = event['ResourceProperties']['botolevel']
     if not loglevel:
-        loglevel = 'warning'
+        loglevel = 'WARNING'
     if not botolevel:
-        botolevel = 'error'
+        botolevel = 'ERROR'
     # Set log verbosity levels
     loglevel = getattr(logging, loglevel.upper(), 20)
     botolevel = getattr(logging, botolevel.upper(), 40)
@@ -44,98 +49,93 @@ def log_config(event, loglevel=None, botolevel=None):
     return logging.LoggerAdapter(mainlogger, {'requestid': event['RequestId']})
 
 
-def send(event, context, responseStatus, responseData, physicalResourceId,
+def send(event, context, response_status, response_data, physical_resource_id,
          logger, reason=None):
+    response_url = event['ResponseURL']
+    logger.debug("CFN response URL: {}".format(response_url))
 
-    responseUrl = event['ResponseURL']
-    logger.debug("CFN response URL: " + responseUrl)
-
-    responseBody = {}
-    responseBody['Status'] = responseStatus
-    msg = 'See CloudWatch Log Stream: ' + context.log_stream_name
+    response_body = dict()
+    response_body['Status'] = response_status
+    msg = 'See CloudWatch Log Stream: {}'.format(context.log_stream_name)
     if not reason:
-        responseBody['Reason'] = msg
+        response_body['Reason'] = msg
     else:
-        responseBody['Reason'] = str(reason)[0:255] + ' (' + msg + ')'
-    responseBody['PhysicalResourceId'] = physicalResourceId or 'NONE'
-    responseBody['StackId'] = event['StackId']
-    responseBody['RequestId'] = event['RequestId']
-    responseBody['LogicalResourceId'] = event['LogicalResourceId']
-    if responseData and responseData != {} and responseData != [] and isinstance(responseData, dict):
-        responseBody['Data'] = responseData
+        response_body['Reason'] = str(reason)[0:255] + ' ({})'.format(msg)
+    response_body['PhysicalResourceId'] = physical_resource_id or 'NONE'
+    response_body['StackId'] = event['StackId']
+    response_body['RequestId'] = event['RequestId']
+    response_body['LogicalResourceId'] = event['LogicalResourceId']
+    if response_data and response_data != {} and response_data != [] and isinstance(response_data, dict):
+        response_body['Data'] = response_data
 
-    json_responseBody = json.dumps(responseBody)
+    json_response_body = json.dumps(response_body)
 
-    logger.debug("Response body:\n" + json_responseBody)
+    logger.debug("Response body:\n{}".format(json_response_body))
 
     headers = {
         'content-type': '',
-        'content-length': str(len(json_responseBody))
+        'content-length': str(len(json_response_body))
     }
 
     try:
-        response = requests.put(responseUrl,
-                                data=json_responseBody,
+        response = requests.put(response_url,
+                                data=json_response_body,
                                 headers=headers)
-        logger.info("CloudFormation returned status code: " + response.reason)
+        logger.info("CloudFormation returned status code: {}".format(response.reason))
     except Exception as e:
-        logger.error("send(..) failed executing requests.put(..): " + str(e))
+        logger.error("send(..) failed executing requests.put(..): {}".format(e))
         raise
 
 
-# Function that executes just before lambda excecution times out
+# Function that executes just before lambda execution times out
 def timeout(event, context, logger):
     logger.error("Execution is about to time out, sending failure message")
-    send(event, context, "FAILED", None, None, reason="Execution timed out",
+    send(event, context, "FAILED", {}, None, reason="Execution timed out",
          logger=logger)
 
 
 # Handler function
 def cfn_handler(event, context, create, update, delete, logger, init_failed):
-
-    logger.info("Lambda RequestId: %s CloudFormation RequestId: %s" %
-                (context.aws_request_id, event['RequestId']))
+    logger.info("Lambda RequestId: {} CloudFormation RequestId: {}".format(context.aws_request_id, event['RequestId']))
 
     # Define an object to place any response information you would like to send
     # back to CloudFormation (these keys can then be used by Fn::GetAttr)
-    responseData = {}
+    response_data = {}
 
-    # Define a physicalId for the resource, if the event is an update and the
-    # returned phyiscalid changes, cloudformation will then issue a delete
+    # Define a physical_id for the resource, if the event is an update and the
+    # returned physical_id changes, cloudformation will then issue a delete
     # against the old id
-    physicalResourceId = None
+    physical_resource_id = None
 
-    logger.debug("EVENT: " + str(event))
+    logger.debug("EVENT: {}".format(event))
     # handle init failures
     if init_failed:
-        send(event, context, "FAILED", responseData, physicalResourceId,
-             init_failed, logger=logger)
-        raise
+        send(event, context, "FAILED", response_data, physical_resource_id, logger=logger,  reason=init_failed)
+        raise Exception('FAILED')
 
     # Setup timer to catch timeouts
-    t = threading.Timer((context.get_remaining_time_in_millis()/1000.00)-0.5,
+    t = threading.Timer((context.get_remaining_time_in_millis() / 1000.00) - 0.5,
                         timeout, args=[event, context, logger])
     t.start()
 
     try:
         # Execute custom resource handlers
-        logger.info("Received a %s Request" % event['RequestType'])
+        logger.info("Received a {} Request".format(event['RequestType']))
         if event['RequestType'] == 'Create':
-            physicalResourceId, responseData = create(event, context)
+            physical_resource_id, response_data = create(event, context)
         elif event['RequestType'] == 'Update':
-            physicalResourceId, responseData = update(event, context)
+            physical_resource_id, response_data = update(event, context)
         elif event['RequestType'] == 'Delete':
             delete(event, context)
 
         # Send response back to CloudFormation
         logger.info("Completed successfully, sending response to cfn")
-        send(event, context, "SUCCESS", responseData, physicalResourceId,
+        send(event, context, "SUCCESS", response_data, physical_resource_id,
              logger=logger)
 
     # Catch any exceptions, log the stacktrace, send a failure back to
     # CloudFormation and then raise an exception
     except Exception as e:
         logger.error(e, exc_info=True)
-        send(event, context, "FAILED", responseData, physicalResourceId,
-             reason=e, logger=logger)
-        raise
+        send(event, context, "FAILED", response_data, physical_resource_id, logger=logger, reason=e)
+        raise Exception('FAILED')

--- a/aws/solutions/StackSetsResource/FunctionCode/lambda_function.py
+++ b/aws/solutions/StackSetsResource/FunctionCode/lambda_function.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# stack_set_resource.py
+#
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##################################################################################################
 """
 StackSet via CloudFormation
 """
@@ -5,10 +23,11 @@ StackSet via CloudFormation
 # Next ToDo:
 # Allow for stack Retention
 
-import boto3
-from time import sleep
-from botocore.exceptions import ClientError
 import os
+from time import sleep
+
+import boto3
+from botocore.exceptions import ClientError
 
 import crhelper
 
@@ -21,9 +40,9 @@ init_failed = False
 try:
     # Place initialization code here
     logger.info("Container initialization completed")
-except Exception as e:
-    logger.error(e, exc_info=True)
-    init_failed = e
+except Exception as exception:
+    logger.error(exception, exc_info=True)
+    init_failed = exception
 
 
 def get_stack_from_arn(arn):
@@ -36,7 +55,7 @@ def get_stack_from_arn(arn):
         resource = resourceparts[1]
     else:
         (resource) = resourcepart
-    return(resource)
+    return resource
 
 
 def change_requires_update(attributes, old_values, current_values):
@@ -44,13 +63,13 @@ def change_requires_update(attributes, old_values, current_values):
     # there's been a change.
     for attribute in attributes:
         if (attribute not in old_values) and (attribute in current_values):
-            logger.debug("New value for %s: %s" % (attribute, current_values[attribute]))
+            logger.debug("New value for {}: {}".format(attribute, current_values[attribute]))
             return True
         if (attribute in old_values) and (attribute not in current_values):
-            logger.debug("Value removed for %s: %s" % (attribute, old_values[attribute]))
+            logger.debug("Value removed for {}: {}".format(attribute, old_values[attribute]))
             return True
         if (attribute in old_values) and (attribute in current_values):
-            logger.debug("Evaluating %s: %s vs. %s" % (attribute, current_values[attribute], old_values[attribute]))
+            logger.debug("Evaluating {}: {} vs. {}".format(attribute, current_values[attribute], old_values[attribute]))
             if current_values[attribute] != old_values[attribute]:
                 return True
     return False
@@ -61,17 +80,18 @@ def convert_ops_prefs(ops_prefs):
     # values in the ops_prefs JSON object to ints before we can call the API
     logger.info("Converting Operation Preferences values")
     converted_ops_prefs = {}
-    needs_conversion = set(['FailureToleranceCount', 'FailureTolerancePercentage', 'MaxConcurrentCount', 'MaxConcurrentPercentage'])
+    needs_conversion = set(
+        ['FailureToleranceCount', 'FailureTolerancePercentage', 'MaxConcurrentCount', 'MaxConcurrentPercentage'])
     for key, value in ops_prefs.items():
-        logger.debug("Evaluating %s : %s" % (key, value))
+        logger.debug("Evaluating {} : {}".format(key, value))
         if key in needs_conversion:
-            logger.debug("Converting %s" % key)
+            logger.debug("Converting {}".format(key))
             converted_ops_prefs[key] = int(value)
         elif key == 'RegionOrder':
             converted_ops_prefs['RegionOrder'] = value
         else:
-            logger.warning("Warning: Skipping unknown key: %s in Operation Preferences" % key)
-    return(converted_ops_prefs)
+            logger.warning("Warning: Skipping unknown key: {} in Operation Preferences".format(key))
+    return converted_ops_prefs
 
 
 def expand_tags(tags):
@@ -82,7 +102,7 @@ def expand_tags(tags):
         logger.debug(tag)
         key, value = list(tag.items())[0]
         tags_array.append({'Key': key, 'Value': value})
-    return(tags_array)
+    return tags_array
 
 
 def expand_parameters(params):
@@ -93,40 +113,40 @@ def expand_parameters(params):
         logger.debug(param)
         key, value = list(param.items())[0]
         params_array.append({'ParameterKey': key, 'ParameterValue': value})
-    return(params_array)
+    return params_array
 
 
-def flatten_stacks(stackinstances):
+def flatten_stacks(stack_instances):
     # Stack instances are defined across accounts and regions + parameter
     # overrides.  We want to expand all combinations before we take action.
     flat_stacks = {}
-    for instance in stackinstances:
+    for instance in stack_instances:
         for account in instance['Accounts']:
             for region in instance['Regions']:
-                tuple = ("%s/%s" % (account, region))
-                if tuple in flat_stacks:
-                    raise Exception("%s / %s is defined multiple times" % (account, region))
+                account_region = "{}/{}".format(account, region)
+                if account_region in flat_stacks:
+                    raise Exception("{} / {} is defined multiple times".format(account, region))
                 if 'ParameterOverrides' in instance:
-                    flat_stacks[tuple] = instance['ParameterOverrides']
+                    flat_stacks[account_region] = instance['ParameterOverrides']
                 else:
-                    flat_stacks[tuple] = []
-    return(flat_stacks)
+                    flat_stacks[account_region] = []
+    return flat_stacks
 
 
-def group_by_account(set, flat_stacks):
+def group_by_account(instance_set, flat_stacks):
     # Group regions by account and overrides
     grouped_accounts = {}
-    for instance in set:
+    for instance in instance_set:
         account, region = instance.split('/')
         if account in grouped_accounts:
             if flat_stacks[instance] == grouped_accounts[account]['overrides']:
                 grouped_accounts[account]['regions'].append(region)
             else:
-                raise Exception("The overrides didn't match account group for %s" % instance)
+                raise Exception("The overrides didn't match account group for {}".format(instance))
         else:
             grouped_accounts[account] = {'regions': [region],
                                          'overrides': flat_stacks[instance]}
-    return(grouped_accounts)
+    return grouped_accounts
 
 
 def aggregate_instances(account_list, flat_stacks):
@@ -137,7 +157,6 @@ def aggregate_instances(account_list, flat_stacks):
     # of API calls
     instances = []
     while accounts.keys():
-        instance = {}
         aggregated_accounts = []
         (source_account, values) = accounts.popitem()
         for account in accounts:
@@ -151,7 +170,7 @@ def aggregate_instances(account_list, flat_stacks):
                     'overrides': values['overrides']}
         instances.append(instance)
     logger.debug(instances)
-    return(instances)
+    return instances
 
 
 def create_stacks(set_region, set_name, accts, regions, param_overrides,
@@ -161,8 +180,9 @@ def create_stacks(set_region, set_name, accts, regions, param_overrides,
     retries = 60
     this_try = 0
 
-    logger.info("Creating stack instances with op prefs %s" % ops_prefs)
-    logger.debug("StackSetName: %s, Accounts: %s, Regions: %s, ParameterOverrides: %s" % (set_name, accts, regions, param_overrides))
+    logger.info("Creating stack instances with op prefs {}".format(ops_prefs))
+    logger.debug("StackSetName: {}, Accounts: {}, Regions: {}, ParameterOverrides: {}".format(
+        set_name, accts, regions, param_overrides))
 
     while True:
         try:
@@ -175,45 +195,51 @@ def create_stacks(set_region, set_name, accts, regions, param_overrides,
                 OperationPreferences=ops_prefs,
                 # OperationId='string'
             )
-            return(response)
+            return response
         except ClientError as e:
             if e.response['Error']['Code'] == 'OperationInProgressException':
                 this_try += 1
                 if this_try == retries:
-                    logger.warning("Failed to create stack instances after %s tries" % this_try)
-                    raise Exception("Error creating stack instances: %s" % e)
+                    logger.warning("Failed to create stack instances after {} tries".format(this_try))
+                    raise Exception("Error creating stack instances: {}".format(e))
                 else:
-                    logger.warning("Create stack instances operation in progress for %s in %s. Sleeping for %i seconds." % (set_name, set_region, sleep_time))
+                    logger.warning(
+                        "Create stack instances operation in progress for {} in {}. Sleeping for {} seconds.".format(
+                            set_name, set_region, sleep_time))
                     sleep(sleep_time)
                     continue
             elif e.response['Error']['Code'] == 'Throttling':
                 this_try += 1
                 if this_try == retries:
-                    logger.warning("Failed to create stack instances after %s tries" % this_try)
-                    raise Exception("Error creating stack instances: %s" % e)
+                    logger.warning("Failed to create stack instances after {} tries".format(this_try))
+                    raise Exception("Error creating stack instances: {}".format(e))
                 else:
-                    logger.warning("Throttling exception encountered while creating stack instances. Backing off and retyring. Sleeping for %i seconds." % (sleep_time))
+                    logger.warning(
+                        "Throttling exception encountered while creating stack instances. Backing off and retyring. " 
+                        "Sleeping for {} seconds.".format(sleep_time))
                     sleep(sleep_time)
                     continue
             elif e.response['Error']['Code'] == 'StackSetNotFoundException':
-                raise Exception("No StackSet matching %s found in %s. You must create before creating stack instances." % (set_name, set_region))
+                raise Exception(
+                    "No StackSet matching {} found in {}. You must create before creating stack instances.".format(
+                        set_name, set_region))
             else:
-                raise Exception("Error creating stack instances: %s" % e)
+                raise Exception("Error creating stack instances: {}".format(e))
 
 
-def update_stacks(set_region, set_name, accts, regions, param_overrides,
-                  ops_prefs):
+def update_stacks(set_region, set_name, accts, regions, param_overrides, ops_prefs):
     # Wrapper for update_stack_instances
     sleep_time = 15
     retries = 60
     this_try = 0
 
-    logger.info("Updating stack instances with op prefs %s" % ops_prefs)
+    logger.info("Updating stack instances with op prefs {}".format(ops_prefs))
 
     # UpdateStackInstance only allows stackSetName, not stackSetId,
     # so we need to truncate.
     (set_name, uid) = set_name.split(':')
-    logger.debug("StackSetName: %s, Accounts: %s, Regions: %s, ParameterOverrides: %s" % (set_name, accts, regions, param_overrides))
+    logger.debug("StackSetName: {}, Accounts: {}, Regions: {}, ParameterOverrides: {}".format(
+        set_name, accts, regions, param_overrides))
 
     while True:
         try:
@@ -226,30 +252,36 @@ def update_stacks(set_region, set_name, accts, regions, param_overrides,
                 OperationPreferences=ops_prefs,
                 # OperationId='string'
             )
-            return(response)
+            return response
         except ClientError as e:
             if e.response['Error']['Code'] == 'OperationInProgressException':
                 this_try += 1
                 if this_try == retries:
-                    logger.warning("Failed to update stack instances after %s tries" % this_try)
-                    raise Exception("Error updating stack instances: %s" % e)
+                    logger.warning("Failed to update stack instances after {} tries".format(this_try))
+                    raise Exception("Error updating stack instances: {}".format(e))
                 else:
-                    logger.warning("Update stack instances operation in progress for %s in %s. Sleeping for %i seconds." % (set_name, set_region, sleep_time))
+                    logger.warning(
+                        "Update stack instances operation in progress for {} in {}. Sleeping for {} seconds.".format(
+                            set_name, set_region, sleep_time))
                     sleep(sleep_time)
                     continue
             elif e.response['Error']['Code'] == 'Throttling':
                 this_try += 1
                 if this_try == retries:
-                    logger.warning("Failed to update stack instances after %s tries" % this_try)
-                    raise Exception("Error updating stack instances: %s" % e)
+                    logger.warning("Failed to update stack instances after {} tries".format(this_try))
+                    raise Exception("Error updating stack instances: {}".format(e))
                 else:
-                    logger.warning("Throttling exception encountered while updating stack instances. Backing off and retyring. Sleeping for %i seconds." % (sleep_time))
+                    logger.warning(
+                        "Throttling exception encountered while updating stack instances. Backing off and retyring. " 
+                        "Sleeping for {} seconds.".format(sleep_time))
                     sleep(sleep_time)
                     continue
             elif e.response['Error']['Code'] == 'StackSetNotFoundException':
-                raise Exception("No StackSet matching %s found in %s. You must create before updating stack instances." % (set_name, set_region))
+                raise Exception(
+                    "No StackSet matching {} found in {}. You must create before updating stack instances.".format(
+                        set_name, set_region))
             else:
-                raise Exception("Unexpected error: %s" % e)
+                raise Exception("Unexpected error: {}".format(e))
 
 
 def delete_stacks(set_region, set_id, accts, regions, ops_prefs):
@@ -258,8 +290,8 @@ def delete_stacks(set_region, set_id, accts, regions, ops_prefs):
     retries = 60
     this_try = 0
 
-    logger.info("Deleting stack instances with op prefs %s" % ops_prefs)
-    logger.debug("StackSetName: %s, Accounts: %s, Regions: %s" % (set_id, accts, regions))
+    logger.info("Deleting stack instances with op prefs {}".format(ops_prefs))
+    logger.debug("StackSetName: {}, Accounts: {}, Regions: {}".format(set_id, accts, regions))
 
     while True:
         try:
@@ -272,30 +304,35 @@ def delete_stacks(set_region, set_id, accts, regions, ops_prefs):
                 RetainStacks=False,
                 # OperationId='string'
             )
-            return(response)
+            return response
         except ClientError as e:
             if e.response['Error']['Code'] == 'OperationInProgressException':
                 this_try += 1
                 if this_try == retries:
-                    logger.warning("Failed to delete stack instances after %s tries" % this_try)
-                    raise Exception("Error deleting stack instances: %s" % e)
+                    logger.warning("Failed to delete stack instances after {} tries".format(this_try))
+                    raise Exception("Error deleting stack instances: {}".format(e))
                 else:
-                    logger.warning("Delete stack instances operation in progress for %s in %s. Sleeping for %i seconds." % (set_id, set_region, sleep_time))
+                    logger.warning(
+                        "Delete stack instances operation in progress for {} in {}. Sleeping for {} seconds.".format(
+                            set_id, set_region, sleep_time))
                     sleep(sleep_time)
                     continue
             elif e.response['Error']['Code'] == 'Throttling':
                 this_try += 1
                 if this_try == retries:
-                    logger.warning("Failed to delete stack instances after %s tries" % this_try)
-                    raise Exception("Error deleting stack instances: %s" % e)
+                    logger.warning("Failed to delete stack instances after {} tries".format(this_try))
+                    raise Exception("Error deleting stack instances: {}".format(e))
                 else:
-                    logger.warning("Throttling exception encountered while deleting stack instances. Backing off and retyring. Sleeping for %i seconds." % (sleep_time))
+                    logger.warning(
+                        "Throttling exception encountered while deleting stack instances. Backing off and retyring. " 
+                        "Sleeping for {} seconds.".format(sleep_time))
                     sleep(sleep_time)
                     continue
             elif e.response['Error']['Code'] == 'StackSetNotFoundException':
-                return("No StackSet matching %s found in %s. You must create before deleting stack instances." % (set_id, set_region))
+                return "No StackSet matching {} found in {}. You must create before deleting stack instances.".format(
+                    set_id, set_region)
             else:
-                return("Unexpected error: %s" % e)
+                return "Unexpected error: {}".format(e)
 
 
 def update_stack_set(set_region, set_id, set_description, set_template,
@@ -325,20 +362,22 @@ def update_stack_set(set_region, set_id, set_description, set_template,
             if response['ResponseMetadata']['HTTPStatusCode'] == 200:
                 return set_id
             else:
-                raise Exception("HTTP Error: %s" % response)
+                raise Exception("HTTP Error: {}".format(response))
         except ClientError as e:
             if e.response['Error']['Code'] == 'OperationInProgressException':
                 this_try += 1
                 if this_try == retries:
-                    raise Exception("Failed to update StackSet after %s tries." % this_try)
+                    raise Exception("Failed to update StackSet after {} tries.".format(this_try))
                 else:
-                    logger.warning("Update StackSet operation in progress for %s. Sleeping for %i seconds." % (set_id, sleep_time))
+                    logger.warning(
+                        "Update StackSet operation in progress for {}. Sleeping for {} seconds.".format(
+                            set_id, sleep_time))
                     sleep(sleep_time)
                     continue
             elif e.response['Error']['Code'] == 'StackSetNotEmptyException':
-                raise Exception("There are still stacks in set %s. You must delete these first." % (set_id))
+                raise Exception("There are still stacks in set {}. You must delete these first.".format(set_id))
             else:
-                raise Exception("Unexpected error: %s" % e)
+                raise Exception("Unexpected error: {}".format(e))
 
 
 def create(event, context):
@@ -347,23 +386,25 @@ def create(event, context):
 
     Create StackSet resource and any stack instances specified in the template.
     """
+    # pylint: disable=unused-argument
     # Collect everything we need to create the stack set
 
     # optional
     if 'StackSetName' in event['ResourceProperties']:
         set_name = event['ResourceProperties']['StackSetName']
     else:
-        set_name = "%s-%s" % (get_stack_from_arn(event['StackId']), event['LogicalResourceId'])
+        set_name = "{}-{}".format(get_stack_from_arn(event['StackId']), event['LogicalResourceId'])
 
     if 'StackSetDescription' in event['ResourceProperties']:
         set_description = event['ResourceProperties']['StackSetDescription']
     else:
-        set_description = "This StackSet belongs to the CloudFormation stack %s." % get_stack_from_arn(event['StackId'])
+        set_description = "This StackSet belongs to the CloudFormation stack {}.".format(
+            get_stack_from_arn(event['StackId']))
 
     if 'OperationPreferences' in event['ResourceProperties']:
-        set_opsprefs = convert_ops_prefs(event['ResourceProperties']['OperationPreferences'])
+        set_ops_prefs = convert_ops_prefs(event['ResourceProperties']['OperationPreferences'])
     else:
-        set_opsprefs = {}
+        set_ops_prefs = {}
 
     if 'Tags' in event['ResourceProperties']:
         set_tags = expand_tags(event['ResourceProperties']['Tags'])
@@ -379,7 +420,7 @@ def create(event, context):
         set_admin_role_arn = event['ResourceProperties']['AdministrationRoleARN']
     else:
         set_admin_role_arn = ''
-    
+
     if 'ExecutionRoleName' in event['ResourceProperties']:
         set_exec_role_name = event['ResourceProperties']['ExecutionRoleName']
     else:
@@ -392,7 +433,6 @@ def create(event, context):
 
     # Required
     set_template = event['ResourceProperties']['TemplateURL']
-    
 
     # Create the StackSet
     try:
@@ -413,13 +453,13 @@ def create(event, context):
         if response['ResponseMetadata']['HTTPStatusCode'] == 200:
             set_id = response['StackSetId']
         else:
-            raise Exception("HTTP Error: %s" % response)
+            raise Exception("HTTP Error: {}".format(response))
     except ClientError as e:
         if e.response['Error']['Code'] == 'NameAlreadyExistsException':
-            raise Exception("A StackSet called %s already exists." % set_name)
+            raise Exception("A StackSet called {} already exists.".format(set_name))
         else:
-            raise Exception("Unexpected error: %s" % e)
-    logger.info("Created StackSet: %s" % set_id)
+            raise Exception("Unexpected error: {}".format(e))
+    logger.info("Created StackSet: {}".format(set_id))
     physical_resource_id = set_id
 
     # Deploy stack to accounts and regions if defined.
@@ -433,7 +473,8 @@ def create(event, context):
             param_overrides = expand_parameters(instance['ParameterOverrides'])
         else:
             param_overrides = []
-        logger.debug("Stack Instance: Regions: %s : Accounts: %s : Parameters: %s" % (instance['Regions'], instance['Accounts'], param_overrides))
+        logger.debug("Stack Instance: Regions: {} : Accounts: {} : Parameters: {}".format(
+            instance['Regions'], instance['Accounts'], param_overrides))
 
         # Make sure every stack instance defines both a list of accounts and
         # a list of regions
@@ -442,14 +483,15 @@ def create(event, context):
         elif instance['Regions'][0] == '' and instance['Accounts'][0] != '':
             raise Exception("You must specify at least one region with a list of accounts.")
         elif instance['Regions'][0] != '' and instance['Accounts'][0] != '':
-            logger.info("Creating stacks in accounts: %s and regions: %s" % (instance['Accounts'], instance['Regions']))
+            logger.info("Creating stacks in accounts: %s and regions: {}".format(
+                instance['Accounts'], instance['Regions']))
             response = create_stacks(
-                    os.environ['AWS_REGION'],
-                    set_id,
-                    instance['Accounts'],
-                    instance['Regions'],
-                    param_overrides,
-                    set_opsprefs
+                os.environ['AWS_REGION'],
+                set_id,
+                instance['Accounts'],
+                instance['Regions'],
+                param_overrides,
+                set_ops_prefs
             )
             logger.debug(response)
     response_data = {}
@@ -462,16 +504,15 @@ def update(event, context):
 
     Update StackSet resource and/or any stack instances specified in the template.
     """
-
     # Collect everything we need to update the stack set
     set_id = event['PhysicalResourceId']
 
     # Process the Operational Preferences (if any)
     if 'OperationPreferences' in event['ResourceProperties']:
-        set_opsprefs = convert_ops_prefs(event['ResourceProperties']['OperationPreferences'])
+        set_ops_prefs = convert_ops_prefs(event['ResourceProperties']['OperationPreferences'])
     else:
-        set_opsprefs = {}
-    logger.debug("OperationPreferences: %s" % set_opsprefs)
+        set_ops_prefs = {}
+    logger.debug("OperationPreferences: {}".format(set_ops_prefs))
 
     # Circumstances under which we update the StackSet itself
     stack_set_attributes = [
@@ -479,7 +520,7 @@ def update(event, context):
         'Parameters',
         'Tags',
         'Capabilities',
-        'StackSetDecription'
+        'StackSetDescription'
     ]
     stack_set_needs_update = change_requires_update(stack_set_attributes,
                                                     event['OldResourceProperties'],
@@ -495,8 +536,9 @@ def update(event, context):
         elif 'StackSetDescription' in event['OldResourceProperties']:
             set_description = event['OldResourceProperties']['StackSetDescription']
         else:
-            set_description = "This StackSet belongs to the CloudFormation stack %s." % get_stack_from_arn(event['StackId'])
-        logger.debug("StackSetDescription: %s" % set_description)
+            set_description = "This StackSet belongs to the CloudFormation stack {}.".format(
+                get_stack_from_arn(event['StackId']))
+        logger.debug("StackSetDescription: {}".format(set_description))
 
         if 'Capabilities' in event['ResourceProperties']:
             set_capabilities = event['ResourceProperties']['Capabilities']
@@ -504,7 +546,7 @@ def update(event, context):
             set_capabilities = event['OldResourceProperties']['Capabilities']
         else:
             set_capabilities = []
-        logger.debug("Capabilities: %s" % set_capabilities)
+        logger.debug("Capabilities: {}".format(set_capabilities))
 
         if 'Tags' in event['ResourceProperties']:
             set_tags = expand_tags(event['ResourceProperties']['Tags'])
@@ -512,7 +554,7 @@ def update(event, context):
             set_tags = expand_tags(event['OldResourceProperties']['Tags'])
         else:
             set_tags = []
-        logger.debug("Tags: %s" % set_tags)
+        logger.debug("Tags: {}".format(set_tags))
 
         if 'Parameters' in event['ResourceProperties']:
             set_parameters = expand_parameters(event['ResourceProperties']['Parameters'])
@@ -520,7 +562,7 @@ def update(event, context):
             set_parameters = expand_parameters(event['OldResourceProperties']['Parameters'])
         else:
             set_parameters = []
-        logger.debug("Parameters: %s" % set_parameters)
+        logger.debug("Parameters: {}".format(set_parameters))
 
         # Required properties
         logger.info("Evaluating required properties")
@@ -530,13 +572,13 @@ def update(event, context):
             set_template = event['OldResourceProperties']['TemplateURL']
         else:
             raise Exception('Template URL not found during update event')
-        logger.debug("TemplateURL: %s" % set_template)
+        logger.debug("TemplateURL: {}".format(set_template))
 
         # Update the StackSet
-        logger.info("Updating StackSet resource %s" % set_id)
+        logger.info("Updating StackSet resource {}".format(set_id))
         update_stack_set(os.environ['AWS_REGION'], set_id, set_description,
                          set_template, set_parameters, set_capabilities,
-                         set_tags, set_opsprefs)
+                         set_tags, set_ops_prefs)
 
     # Now, look for changes to stack instances
     logger.info("Evaluating stack instances")
@@ -559,77 +601,80 @@ def update(event, context):
 
     # Launch all new stack instances
     if to_add:
-        logger.info("Adding stack instances:  %s" % to_add)
+        logger.info("Adding stack instances:  {}".format(to_add))
 
         # Aggregate accounts with similar regions to reduce number of API calls
         add_instances = aggregate_instances(to_add, new_stacks)
 
         # Add stack instances
         for instance in add_instances:
-            logger.debug("Add aggregated accounts: %s and regions: %s and overrides: %s" % (instance['accounts'], instance['regions'], instance['overrides']))
+            logger.debug("Add aggregated accounts: {} and regions: {} and overrides: {}".format(
+                instance['accounts'], instance['regions'], instance['overrides']))
             if 'overrides' in instance:
                 param_overrides = expand_parameters(instance['overrides'])
             else:
                 param_overrides = []
 
             response = create_stacks(
-                    os.environ['AWS_REGION'],
-                    set_id,
-                    instance['accounts'],
-                    instance['regions'],
-                    param_overrides,
-                    set_opsprefs
+                os.environ['AWS_REGION'],
+                set_id,
+                instance['accounts'],
+                instance['regions'],
+                param_overrides,
+                set_ops_prefs
             )
             logger.debug(response)
 
     # Delete all old stack instances
     if to_delete:
-        logger.info("Deleting stack instances: %s" % to_delete)
+        logger.info("Deleting stack instances: {}".format(to_delete))
 
         # Aggregate accounts with similar regions to reduce number of API calls
         delete_instances = aggregate_instances(to_delete, old_stacks)
 
         # Add stack instances
         for instance in delete_instances:
-            logger.debug("Delete aggregated accounts: %s and regions: %s" % (instance['accounts'], instance['regions']))
+            logger.debug("Delete aggregated accounts: {} and regions: {}".format(
+                instance['accounts'], instance['regions']))
             response = delete_stacks(
-                    os.environ['AWS_REGION'],
-                    set_id,
-                    instance['accounts'],
-                    instance['regions'],
-                    set_opsprefs
+                os.environ['AWS_REGION'],
+                set_id,
+                instance['accounts'],
+                instance['regions'],
+                set_ops_prefs
             )
             logger.debug(response)
 
     # Determine if any existing instances need to be updated
     if to_compare:
-        logger.info("Examining stack instances: %s" % to_compare)
+        logger.info("Examining stack instances: {}".format(to_compare))
 
         # Update any stacks in both lists, but with new overrides
         to_update = []
         for instance in to_compare:
             if old_stacks[instance] == new_stacks[instance]:
-                logger.debug("%s: SAME!" % instance)
+                logger.debug("{}: SAME!".format(instance))
             else:
-                logger.debug("%s: DIFFERENT!" % instance)
+                logger.debug("{}: DIFFERENT!".format(instance))
                 to_update.append(instance)
 
         # Aggregate accounts with similar regions to reduce number of API calls
         update_instances = aggregate_instances(to_update, new_stacks)
         for instance in update_instances:
-            logger.debug("Update aggregated accounts: %s and regions: %s with overrides %s" % (instance['accounts'], instance['regions'], instance['overrides']))
+            logger.debug("Update aggregated accounts: {} and regions: {} with overrides {}".format(
+                instance['accounts'], instance['regions'], instance['overrides']))
             if 'overrides' in instance:
                 param_overrides = expand_parameters(instance['overrides'])
             else:
                 param_overrides = []
 
             response = update_stacks(
-                    os.environ['AWS_REGION'],
-                    set_id,
-                    instance['accounts'],
-                    instance['regions'],
-                    param_overrides,
-                    set_opsprefs
+                os.environ['AWS_REGION'],
+                set_id,
+                instance['accounts'],
+                instance['regions'],
+                param_overrides,
+                set_ops_prefs
             )
             logger.debug(response)
 
@@ -661,27 +706,26 @@ def delete(event, context):
     if 'StackInstances' in event['ResourceProperties']:
         # Check for Operation Preferences
         if 'OperationPreferences' in event['ResourceProperties']:
-            set_opsprefs = convert_ops_prefs(event['ResourceProperties']['OperationPreferences'])
+            set_ops_prefs = convert_ops_prefs(event['ResourceProperties']['OperationPreferences'])
         else:
-            set_opsprefs = {}
+            set_ops_prefs = {}
 
         # Iterate over stack instances
         for instance in event['ResourceProperties']['StackInstances']:
-            logger.debug("Stack Instance: Regions: %s : Accounts: %s" % (instance['Regions'], instance['Accounts']))
+            logger.debug("Stack Instance: Regions: {} : Accounts: {}".format(instance['Regions'], instance['Accounts']))
 
-            logger.info("Removing existing stacks from stack set %s" % set_id)
+            logger.info("Removing existing stacks from stack set {}".format(set_id))
 
             response = delete_stacks(
                 os.environ['AWS_REGION'],
                 set_id,
                 instance['Accounts'],
                 instance['Regions'],
-                set_opsprefs
+                set_ops_prefs
             )
             logger.debug(response)
 
-    client = boto3.client('cloudformation',
-                          region_name=os.environ['AWS_REGION'])
+    client = boto3.client('cloudformation', region_name=os.environ['AWS_REGION'])
 
     # Retry loop
     logger.info('Deleting stack set')
@@ -693,20 +737,22 @@ def delete(event, context):
             if response['ResponseMetadata']['HTTPStatusCode'] == 200:
                 return
             else:
-                raise Exception("HTTP Error: %s" % response)
+                raise Exception("HTTP Error: {}".format(response))
         except ClientError as e:
             if e.response['Error']['Code'] == 'OperationInProgressException':
                 this_try += 1
                 if this_try == retries:
-                    raise Exception("Failed to delete StackSet after %s tries." % this_try)
+                    raise Exception("Failed to delete StackSet after {} tries.".format(this_try))
                 else:
-                    logger.warning("Delete StackSet operation in progress for %s. Sleeping for %i seconds." % (set_id, sleep_time))
+                    logger.warning(
+                        "Delete StackSet operation in progress for {}. Sleeping for {} seconds.".format(
+                            set_id, sleep_time))
                     sleep(sleep_time)
                     continue
             elif e.response['Error']['Code'] == 'StackSetNotEmptyException':
-                raise Exception("There are still stacks in set %s. You must delete these first." % (set_id))
+                raise Exception("There are still stacks in set {}. You must delete these first.".format(set_id))
             else:
-                raise Exception("Unexpected error: %s" % e)
+                raise Exception("Unexpected error: {}".format(e))
 
 
 def handler(event, context):
@@ -716,5 +762,4 @@ def handler(event, context):
     # update the logger with event info
     global logger
     logger = crhelper.log_config(event)
-    return crhelper.cfn_handler(event, context, create, update, delete, logger,
-                                init_failed)
+    return crhelper.cfn_handler(event, context, create, update, delete, logger, init_failed)

--- a/aws/solutions/StackSetsResource/FunctionCode/lambda_function.py
+++ b/aws/solutions/StackSetsResource/FunctionCode/lambda_function.py
@@ -419,12 +419,12 @@ def create(event, context):
     if 'AdministrationRoleARN' in event['ResourceProperties']:
         set_admin_role_arn = event['ResourceProperties']['AdministrationRoleARN']
     else:
-        set_admin_role_arn = 'arn:aws:iam:::role/AWSCloudFormationStackSetAdministrationRole'
+        set_admin_role_arn = ''
 
     if 'ExecutionRoleName' in event['ResourceProperties']:
         set_exec_role_name = event['ResourceProperties']['ExecutionRoleName']
     else:
-        set_exec_role_name = 'AWSCloudFormationStackSetExecutionRole'
+        set_exec_role_name = ''
 
     if 'Parameters' in event['ResourceProperties']:
         set_parameters = expand_parameters(event['ResourceProperties']['Parameters'])

--- a/aws/solutions/StackSetsResource/FunctionCode/lambda_function.py
+++ b/aws/solutions/StackSetsResource/FunctionCode/lambda_function.py
@@ -54,7 +54,7 @@ def get_stack_from_arn(arn):
         resourceparts = resourcepart.split('/')
         resource = resourceparts[1]
     else:
-        (resource) = resourcepart
+        resource = resourcepart
     return resource
 
 
@@ -419,12 +419,12 @@ def create(event, context):
     if 'AdministrationRoleARN' in event['ResourceProperties']:
         set_admin_role_arn = event['ResourceProperties']['AdministrationRoleARN']
     else:
-        set_admin_role_arn = ''
+        set_admin_role_arn = 'arn:aws:iam:::role/AWSCloudFormationStackSetAdministrationRole'
 
     if 'ExecutionRoleName' in event['ResourceProperties']:
         set_exec_role_name = event['ResourceProperties']['ExecutionRoleName']
     else:
-        set_exec_role_name = ''
+        set_exec_role_name = 'AWSCloudFormationStackSetExecutionRole'
 
     if 'Parameters' in event['ResourceProperties']:
         set_parameters = expand_parameters(event['ResourceProperties']['Parameters'])


### PR DESCRIPTION
Hi Chuck,

I've applied a little lint/refactor in the 2 functions to make the code more pythonic.
Changes are:

- Renamed variables to lower case only (ex: `resourceId` to `resource_id`
- Replaced the string concatenation with `.format()` string method ([PEP3101](https://www.python.org/dev/peps/pep-3101/))
- Removed some extra parenthesys `()`
- Removed extra `#` in the header 
- Used 120 cols as the max line lenght (Yeah, blame me for not being completely [PEP8](https://www.python.org/dev/peps/pep-0008/), but nowadays 120 is the new normal :-) )
- Minor bugfixes