### PR TITLE
Updated regions for SQSFIFOQueue.json

### DIFF
--- a/aws/services/SQS/SQSFIFOQueue.json
+++ b/aws/services/SQS/SQSFIFOQueue.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Best Practice SQS FIFO Queue, only avialable in us-east-1, us-west-2, ue-west-1 at time of template creation.",
+  "Description": "Best Practice SQS FIFO Queue, only available in us-east-1, us-east-2, us-west-2, eu-west-1, ap-northeast-1, ap-southeast-2 at time of template creation.",
   "Parameters": {
     "ContentBasedDeduplication": {
       "Description": "specifies whether to enable content-based deduplication",


### PR DESCRIPTION
# WHAT IS THIS

I updated comments of `SQSFIFOQueue.json`.

# WHY

Supported regions of SQS FIFO Queue was updated on Nov 8.


- Amazon SQS FIFO Queues Now Available in Asia Pacific (Tokyo) and Asia Pacific (Sydney) Regions
    - https://aws.amazon.com/about-aws/whats-new/2018/11/amazon-sqs-fifo-asia-pacific-tokyo-sydney/