### PR TITLE
Remove http:// from dns resource record creation

### DIFF
--- a/aws/services/S3/S3_Website_With_CloudFront_Distribution.yaml
+++ b/aws/services/S3/S3_Website_With_CloudFront_Distribution.yaml
@@ -82,7 +82,7 @@ Resources:
       Type: CNAME
       TTL: '900'
       ResourceRecords:
-      - !Join ['', ['http://', !GetAtt [WebsiteCDN, DomainName]]]
+      - !GetAtt [WebsiteCDN, DomainName]
 Outputs:
   WebsiteURL:
     Value: !Join ['', ['http://', !Ref 'WebsiteDNSName']]


### PR DESCRIPTION
Not sure why it's there, but when creating the CNAME record, this template adds 'https://' to the value, which causes the custom CNAME to not be resolved.  