### PR TITLE
Added support for updating strings containing decimal placeholders within resources and changed naming format of resources to add iteration count to name

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/Count/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/Count/README.md
@@ -40,7 +40,7 @@ The `Count` macro provides a template-wide `Count` property for CloudFormation r
 
 To make use of the macro, add `Transform: Count` to the top level of your CloudFormation template.
 
-Then specify permissions using a more natural syntax:
+Then specify multipe values using a more natural syntax:
 
 ```yaml
 AWSTemplateFormatVersion: "2010-09-09"
@@ -53,10 +53,64 @@ Resources:
     Type: AWS:::SQS::Queue
     Count: 2
 ```
+#### Note
+This will cause the resource "Bucket" to be multiplied 3 times. The new template will contain Bucket1, Bucket2 and Bucket3 but will not contain Bucket as this will be removed.
 
-### Important
+### Using decimal placeholders
+When resources are multiplied, you can put a decimal placeholder %d into any string value that you wish to be replaced with the iterator index number.
+
+e.g. 
+```yaml
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: Count
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags:
+        - Key: TestKey
+          Value: my bucket %d
+    Count: 3
+```
+
+Using this example, the processed template will result become:
+```yaml
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Bucket1:
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags:
+        - Key: TestKey
+          Value: my bucket 1
+  Bucket2:
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags:
+        - Key: TestKey
+          Value: my bucket 2
+  Bucket3:
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags:
+        - Key: TestKey
+          Value: my bucket 3
+```
+
+### Important - Naming resources
 
 You cannot use Count on resources that use a hardcoded name (`Name:` property). Duplicate names will cause a CloudFormation runtime failure.
+If you wish to specify a name then you can use the decimal place holder %d in the name which will cause the name to incorporate the iterator value.
+
+e.g. 
+```yaml
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Bucket1:
+    Type: AWS::S3::Bucket
+    Properties:
+        BucketName: MyBucket%d
+```
 
 ## Author
 

--- a/aws/services/CloudFormation/MacrosExamples/Count/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/Count/README.md
@@ -40,7 +40,7 @@ The `Count` macro provides a template-wide `Count` property for CloudFormation r
 
 To make use of the macro, add `Transform: Count` to the top level of your CloudFormation template.
 
-TO create multiple copies of a resource, add a Count propert with an integer value.
+To create multiple copies of a resource, add a Count propert with an integer value.
 
 ```yaml
 AWSTemplateFormatVersion: "2010-09-09"

--- a/aws/services/CloudFormation/MacrosExamples/Count/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/Count/README.md
@@ -40,7 +40,7 @@ The `Count` macro provides a template-wide `Count` property for CloudFormation r
 
 To make use of the macro, add `Transform: Count` to the top level of your CloudFormation template.
 
-Then specify multipe values using a more natural syntax:
+TO create multiple copies of a resource, add a Count propert with an integer value.
 
 ```yaml
 AWSTemplateFormatVersion: "2010-09-09"

--- a/aws/services/CloudFormation/MacrosExamples/Count/src/index.py
+++ b/aws/services/CloudFormation/MacrosExamples/Count/src/index.py
@@ -1,7 +1,5 @@
-""" Multiply resources inside a cloudfomration template """
-
 import copy
-
+import json
 
 def process_template(template):
     new_template = copy.deepcopy(template)
@@ -9,20 +7,48 @@ def process_template(template):
 
     for name, resource in template['Resources'].items():
         if 'Count' in resource:
+            #Get the number of times to multiply the resource
             count = new_template['Resources'][name].pop('Count')
-            multiplied = multiply(name, new_template['Resources'][name], count)
-            if not set(multiplied.keys()) & set(new_template['Resources'].keys()):
-                new_template['Resources'].update(multiplied)
+            print("Found 'Count' property with value {} in '{}' resource....multiplying!".format(count,name))            
+            #Remove the original resource from the template but take a local copy of it
+            resourceToMultiply = new_template['Resources'].pop(name)
+            #Create a new block of the resource multiplied with names ending in the iterator and the placeholders substituted
+            resourcesAfterMultiplication = multiply(name, resourceToMultiply, count)
+            if not set(resourcesAfterMultiplication.keys()) & set(new_template['Resources'].keys()):
+                new_template['Resources'].update(resourcesAfterMultiplication)
             else:
                 status = 'failed'
                 return status, template
+        else:
+            print("Did not find 'Count' property in '{}' resource....Nothing to do!".format(name))
     return status, new_template
 
+def update_placeholder(resource_structure, iteration):
+    #Convert the json into a string
+    resourceString = json.dumps(resource_structure)
+    #Count the number of times the placeholder is found in the string
+    placeHolderCount = resourceString.count('%d')
+
+    #If the placeholder is found then replace it
+    if placeHolderCount > 0:
+        print("Found {} occurrences of decimal placeholder in JSON, replacing with iterator value {}".format(placeHolderCount, iteration))
+        #Make a list of the values that we will use to replace the decimal placeholders - the values will all be the same
+        placeHolderReplacementValues = [iteration] * placeHolderCount
+        #Replace the decimal placeholders using the list - the syntax below expands the list
+        resourceString = resourceString % (*placeHolderReplacementValues,)
+        #Convert the string back to json and return it
+        return json.loads(resourceString)
+    else:
+        print("No occurences of decimal placeholder found in JSON, therefore nothing will be replaced")
+        return resource_structure
 
 def multiply(resource_name, resource_structure, count):
     resources = {}
-    for iteration in range(1, count):
-        resources[resource_name+str(iteration)] = resource_structure
+    #Loop according to the number of times we want to multiply, creating a new resource each time
+    for iteration in range(1, (count + 1)):
+        print("Multiplying '{}', iteration count {}".format(resource_name,iteration))        
+        multipliedResourceStructure = update_placeholder(resource_structure,iteration)
+        resources[resource_name+str(iteration)] = multipliedResourceStructure
     return resources
 
 

--- a/aws/services/CloudFormation/MacrosExamples/Count/test_2.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/Count/test_2.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform:
+  - Count
+Resources:
+  BucketToCopy:
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags:
+        - Key: TestKey
+          Value: my bucket %d
+        - Key: Another key
+          Value: "%d value"
+    Count: 3


### PR DESCRIPTION
It is now possible to use the decimal placeholder %d in a string within the resource and this value will be substituted with the iteration value count.

This can be used for naming the resources but also in tags to allow the resources to be differentiated from the each other.

Also, instead of adding new resources with the iteration count added to the original name such as:

e.g.

Bucket <-- Original resource
Buket1 <- Copy 1
Bucket2 <- Copy2 

The original resource is removed and copies of it are created all using the iterator value.

e.g. 
Bucket1 <- Copy 1
Bucket2 <- Copy 2
Bucket3 <- Copy 3

I believe this is more natural.
