### PR TITLE
Remove break and json decode

### DIFF
--- a/aws/solutions/lambda-backed-cloudformation-custom-resources/Fetch-AMI-From-Parameter-Store/lambda_function.py
+++ b/aws/solutions/lambda-backed-cloudformation-custom-resources/Fetch-AMI-From-Parameter-Store/lambda_function.py
@@ -29,16 +29,15 @@ def lambda_handler(event, context):
         elif event['RequestType'] == 'Create':
             print "create"
             client = boto3.client('ssm')
-            ami_id = json.loads(client.get_parameter(Name=parameter_name)['Parameter']['Value'])['image_id']
+            ami_id = client.get_parameter(Name=parameter_name)['Parameter']['Value']
             print ami_id
         elif event['RequestType'] == 'Update':
             print "update"
             client = boto3.client('ssm')
-            ami_id = json.loads(client.get_parameter(Name=parameter_name)['Parameter']['Value'])['image_id']
+            ami_id = client.get_parameter(Name=parameter_name)['Parameter']['Value']
             print ami_id
         responseStatus = 'SUCCESS'
         responseData = {'AMI': ami_id}
-        break
     except Exception as e:
         print e
         responseStatus = 'FAILURE'
@@ -67,4 +66,3 @@ def sendResponse(event, context, responseStatus, responseData, reason=None, phys
         print "Status code: " + response.reason
     except Exception as e:
         print "send(..) failed executing requests.put(..): " + str(e)
-


### PR DESCRIPTION
*Issue #, if available:*
Current Python script errors at the break and causes CloudFormation custom resource creation to hang. 

*Description of changes:*
Removing the break so a failure response can be sent back to CloudFormation. Also removing json decode as image ID can be fetched from SSM param store and returned correctly without decoding.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
