### PR TITLE
Issue #161 : Corrected S3 websites endpoint suffixes and added support for more regions

### DIFF
--- a/aws/services/S3/S3_Website_With_CloudFront_Distribution.yaml
+++ b/aws/services/S3/S3_Website_With_CloudFront_Distribution.yaml
@@ -23,24 +23,32 @@ Mappings:
       Suffix: .s3-website-us-west-2.amazonaws.com
     eu-west-1:
       Suffix: .s3-website-eu-west-1.amazonaws.com
+    eu-west-2:
+      Suffix: .s3-website.eu-west-2.amazonaws.com
+    eu-west-3:
+      Suffix: .s3-website.eu-west-3.amazonaws.com
+    eu-north-1:
+      Suffix: .s3-website.eu-north-1.amazonaws.com
     ap-northeast-1:
       Suffix: .s3-website-ap-northeast-1.amazonaws.com
     ap-northeast-2:
-      Suffix: .s3-website-ap-northeast-2.amazonaws.com
+      Suffix: .s3-website.ap-northeast-2.amazonaws.com
     ap-southeast-1:
       Suffix: .s3-website-ap-southeast-1.amazonaws.com
     ap-southeast-2:
       Suffix: .s3-website-ap-southeast-2.amazonaws.com
     ap-south-1:
-      Suffix: .s3-website-ap-south-1.amazonaws.com
+      Suffix: .s3-website.ap-south-1.amazonaws.com
     us-east-2:
-      Suffix: .s3-website-us-east-2.amazonaws.com
+      Suffix: .s3-website.us-east-2.amazonaws.com
     sa-east-1:
       Suffix: .s3-website-sa-east-1.amazonaws.com
     cn-north-1:
       Suffix: .s3-website.cn-north-1.amazonaws.com.cn
     eu-central-1:
       Suffix: .s3-website.eu-central-1.amazonaws.com
+    ca-central-1:
+      Suffix: .s3-website.ca-central-1.amazonaws.com
 Resources:
   S3BucketForWebsiteContent:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
Issue #161

Description: 

1. There was a mistake in website endpoint suffixes for S3 Buckets for the following regions:
    - Asia Pacific (Seoul)
    - Asia Pacific (Mumbai)
    - US East (Ohio)
2. Support for the following regions has been added in the template:
    - Canada (Central) 
    - EU (Stockholm)
    - EU (Paris)
    - EU (London)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
