### PR TITLE
Fix typo in 'CloudWatchAgent' template descriptions.

### DIFF
--- a/aws/solutions/AmazonCloudWatchAgent/inline/amazon_linux.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/amazon_linux.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on amazon linux. It was validated on amazon linux 2'
+Description: 'Template to install CloudWatchAgent on amazon linux. It was validated on amazon linux 2'
 Parameters:
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance

--- a/aws/solutions/AmazonCloudWatchAgent/inline/centos.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/centos.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on centos. It was validated on centos 7'
+Description: 'Template to install CloudWatchAgent on centos. It was validated on centos 7'
 Parameters:
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance

--- a/aws/solutions/AmazonCloudWatchAgent/inline/debian.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/debian.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on debian. It was validated on debian 8'
+Description: 'Template to install CloudWatchAgent on debian. It was validated on debian 8'
 Parameters:
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance

--- a/aws/solutions/AmazonCloudWatchAgent/inline/redhat.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/redhat.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on redhat. It was validated on redhat 7.5'
+Description: 'Template to install CloudWatchAgent on redhat. It was validated on redhat 7.5'
 Parameters:
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance

--- a/aws/solutions/AmazonCloudWatchAgent/inline/suse.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/suse.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on suse. It was validated on suse 12'
+Description: 'Template to install CloudWatchAgent on suse. It was validated on suse 12'
 Parameters:
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance

--- a/aws/solutions/AmazonCloudWatchAgent/inline/ubuntu.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/ubuntu.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on ubuntu. It was validated on ubuntu 16'
+Description: 'Template to install CloudWatchAgent on ubuntu. It was validated on ubuntu 16'
 Parameters:
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance

--- a/aws/solutions/AmazonCloudWatchAgent/inline/windows.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/windows.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on windows. It was validated on windows 2016'
+Description: 'Template to install CloudWatchAgent on windows. It was validated on windows 2016'
 Parameters:
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/amazon_linux.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/amazon_linux.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on amazon linux. It was validated on amazon linux 2'
+Description: 'Template to install CloudWatchAgent on amazon linux. It was validated on amazon linux 2'
 Parameters:
   SSMKey :
     Description: Name of parameter store which contains the json configuration of CWAgent.

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/centos.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/centos.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on centos. It was validated on centos 7'
+Description: 'Template to install CloudWatchAgent on centos. It was validated on centos 7'
 Parameters:
   SSMKey :
     Description: Name of parameter store which contains the json configuration of CWAgent.

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/debian.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/debian.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on debian. It was validated on debian 8'
+Description: 'Template to install CloudWatchAgent on debian. It was validated on debian 8'
 Parameters:
   SSMKey :
     Description: Name of parameter store which contains the json configuration of CWAgent.

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/redhat.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/redhat.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on redhat. It was validated on redhat 7.5'
+Description: 'Template to install CloudWatchAgent on redhat. It was validated on redhat 7.5'
 Parameters:
   SSMKey :
     Description: Name of parameter store which contains the json configuration of CWAgent.

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/suse.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/suse.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on suse. It was validated on suse 12'
+Description: 'Template to install CloudWatchAgent on suse. It was validated on suse 12'
 Parameters:
   SSMKey :
     Description: Name of parameter store which contains the json configuration of CWAgent.

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/ubuntu.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/ubuntu.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on ubuntu. It was validated on ubuntu 16'
+Description: 'Template to install CloudWatchAgent on ubuntu. It was validated on ubuntu 16'
 Parameters:
   SSMKey :
     Description: Name of parameter store which contains the json configuration of CWAgent.

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/windows.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/windows.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWagentAgent on windows. It was validated on windows 2016'
+Description: 'Template to install CloudWatchAgent on windows. It was validated on windows 2016'
 Parameters:
   SSMKey :
     Description: Name of parameter store which contains the json configuration of CWAgent.


### PR DESCRIPTION
Changed `CloudWagentAgent` to `CloudWatchAgent` in all `AmazonCloudWatchAgent` template descriptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
