### PR TITLE
Add Explode macro

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/Explode/.gitignore
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/.gitignore
@@ -1,0 +1,1 @@
+packaged.yml

--- a/aws/services/CloudFormation/MacrosExamples/Explode/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/README.md
@@ -1,0 +1,107 @@
+# Explode CloudFormation Macro
+
+The `Explode` macro provides a template-wide `Explode` property for CloudFormation resources. Similar to the Count macro, it will create multiple copies of a template Resource, but looks up values to inject into each copy in a Mapping.
+
+## How to install and use the Explode macro in your AWS account
+
+### Deploying
+
+1. You will need an S3 bucket to store the CloudFormation artifacts. If you don't have one already, create one with `aws s3 mb s3://<bucket name>`
+
+2. Package the Macro CloudFormation template. The provided template uses [the AWS Serverless Application Model](https://aws.amazon.com/about-aws/whats-new/2016/11/introducing-the-aws-serverless-application-model/) so must be transformed before you can deploy it.
+
+```shell
+aws cloudformation package \
+    --template-file macro.yaml \
+    --s3-bucket <your bucket name here> \
+    --output-template-file packaged.yaml
+```
+
+3. Deploy the packaged CloudFormation template to a CloudFormation stack:
+
+```shell
+aws cloudformation deploy \
+    --stack-name Explode-macro \
+    --template-file packaged.yaml \
+    --capabilities CAPABILITY_IAM
+```
+
+4. To test out the macro's capabilities, try launching the provided example template:
+
+```shell
+aws cloudformation deploy \
+    --stack-name Explode-test \
+    --template-file test.yaml \
+    --capabilities CAPABILITY_IAM
+```
+
+### Usage
+
+To make use of the macro, add `Transform: Explode` to the top level of your CloudFormation template.
+
+Add a mapping (to the `Mappings` section of your template) which contains the instances of the resource values you want to use. Each entry in the mapping will be used for another copy of the resource, and the values inside it will be copied into that instance. The entry name will be appended to the template resource name, unless a value `ResourceName` is given, which if present will be used at the complete resource name.
+
+For the resource you want to use, add a `Metadata` section, with an `Explode` map, which should contain a `Map` value pointing at the entry from your Mappings which should be used.
+
+Inside the resource properties, you can use `!Explode KEY` to pull the value of `KEY` out of your mapping.
+
+An example is probably in order:
+
+```yaml
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: Explode
+Mappings:
+  BucketMap:
+    Monthly:
+      ResourceName: MyThirtyDayBucket
+      Retention: 30
+    Yearly:
+      Retention: 365
+
+Resources:
+  Bucket:
+    Metadata:
+      Explode:
+        Map: BucketMap
+    Type: AWS::S3::Bucket
+    Properties:
+      LifecycleConfiguration:
+        Rules:
+          -
+            ExpirationInDays: !Explode Retention
+            Status: Enabled
+
+```
+
+This will result in two Bucket resources; one named `MyThirtyDayBucket` with a
+lifecycle rule for 30 day retention, and another named `BucketYearly` with 365
+day retention.
+
+### Important - Naming resources
+
+You cannot use Explode on resources that use a hardcoded name (`Name:`
+property). Duplicate names will cause a CloudFormation runtime failure.
+If you wish to specify a name then you must use `!Explode` with a mapped value
+to make each resource's name unique.
+
+For example:
+
+```yaml
+AWSTemplateFormatVersion: "2010-09-09"
+Mappings:
+  BucketMap:
+    Example:
+      Name: MyExampleBucket
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Metadata:
+      Explode:
+        Map: BucketMap
+    Properties:
+        BucketName: !Explode Name
+```
+
+## Author
+
+[James Seward](https://github.com/jamesoff); AWS Solutions Architect, Amazon Web Services

--- a/aws/services/CloudFormation/MacrosExamples/Explode/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/README.md
@@ -39,7 +39,7 @@ aws cloudformation deploy \
 
 To make use of the macro, add `Transform: Explode` to the top level of your CloudFormation template.
 
-Add a mapping (to the `Mappings` section of your template) which contains the instances of the resource values you want to use. Each entry in the mapping will be used for another copy of the resource, and the values inside it will be copied into that instance. The entry name will be appended to the template resource name, unless a value `ResourceName` is given, which if present will be used at the complete resource name.
+Add a mapping (to the `Mappings` section of your template) which contains the instances of the resource values you want to use. Each entry in the mapping will be used for another copy of the resource, and the values inside it will be copied into that instance. The entry name will be appended to the template resource name, unless a value `ResourceName` is given, which if present will be used as the complete resource name.
 
 For the resource you want to explode, add an `ExplodeMap` value at the top level pointing at the entry from your Mappings which should be used. You can use the same mapping against multiple resource entries.
 

--- a/aws/services/CloudFormation/MacrosExamples/Explode/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/README.md
@@ -41,7 +41,7 @@ To make use of the macro, add `Transform: Explode` to the top level of your Clou
 
 Add a mapping (to the `Mappings` section of your template) which contains the instances of the resource values you want to use. Each entry in the mapping will be used for another copy of the resource, and the values inside it will be copied into that instance. The entry name will be appended to the template resource name, unless a value `ResourceName` is given, which if present will be used at the complete resource name.
 
-For the resource you want to use, add a `Metadata` section, with an `Explode` map, which should contain a `Map` value pointing at the entry from your Mappings which should be used.
+For the resource you want to explode, add an `ExplodeMap` value at the top level pointing at the entry from your Mappings which should be used. You can use the same mapping against multiple resource entries.
 
 Inside the resource properties, you can use `!Explode KEY` to pull the value of `KEY` out of your mapping.
 
@@ -60,9 +60,7 @@ Mappings:
 
 Resources:
   Bucket:
-    Metadata:
-      Explode:
-        Map: BucketMap
+    ExplodeMap: BucketMap
     Type: AWS::S3::Bucket
     Properties:
       LifecycleConfiguration:
@@ -70,7 +68,6 @@ Resources:
           -
             ExpirationInDays: !Explode Retention
             Status: Enabled
-
 ```
 
 This will result in two Bucket resources; one named `MyThirtyDayBucket` with a
@@ -95,9 +92,7 @@ Mappings:
 Resources:
   Bucket:
     Type: AWS::S3::Bucket
-    Metadata:
-      Explode:
-        Map: BucketMap
+    ExplodeMap: BucketMap
     Properties:
         BucketName: !Explode Name
 ```

--- a/aws/services/CloudFormation/MacrosExamples/Explode/lambda/explode.py
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/lambda/explode.py
@@ -48,14 +48,14 @@ def handle_transform(template):
     new_resources = {}
     for resource_name, resource in resources.items():
         try:
-            explode_data = resource['Metadata']['Explode']
+            explode_map = resource['ExplodeMap']
+            del resource['ExplodeMap']
         except KeyError:
-            # This resource does not have Explode metadata, so copy it verbatim
+            # This resource does not have an ExplodeMap, so copy it verbatim
             # and move on
             new_resources[resource_name] = resource
             continue
         try:
-            explode_map = explode_data['Map']
             explode_map_data = mappings[explode_map]
         except KeyError:
             # This resource refers to a mapping entry which doesn't exist, so
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     """
     If run from the command line, parse the file specified and output it
     This is quite naive; CF YAML tags like !GetAtt will break it (as will
-    !Explode, but you can hide that in a string. Probably best to use JSON.
+    !Explode, but you can hide that in a string). Probably best to use JSON.
     Releatedly, always outputs JSON.
     """
     if len(sys.argv) == 2:

--- a/aws/services/CloudFormation/MacrosExamples/Explode/lambda/explode.py
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/lambda/explode.py
@@ -1,0 +1,119 @@
+"""
+CloudFormation template transform macro: Explode
+"""
+
+import re
+import sys
+
+
+EXPLODE_RE = re.compile(r'(?i)!Explode (?P<explode_key>\w+)')
+
+
+def walk_resource(resource, map_data):
+    """Recursively process a resource."""
+    new_resource = {}
+    for key, value in resource.items():
+        if isinstance(value, dict):
+            new_resource[key] = walk_resource(value, map_data)
+        elif isinstance(value, list):
+            new_resource[key] = [walk_resource(x, map_data) for x in value]
+        elif isinstance(value, str):
+            match = EXPLODE_RE.search(value)
+            while match:
+                explode_key = match.group('explode_key')
+                try:
+                    replace_value = map_data[explode_key]
+                except KeyError:
+                    print("Missing item {} in mapping while processing {}: {}".format(
+                        explode_key,
+                        key,
+                        value))
+                if isinstance(replace_value, int):
+                    value = replace_value
+                    # No further explosion is possible on an int
+                    match = None
+                else:
+                    value = value.replace(match.group(0), replace_value)
+                    match = EXPLODE_RE.search(value)
+            new_resource[key] = value
+        else:
+            new_resource[key] = value
+    return new_resource
+
+
+def handle_transform(template):
+    """Go through template and explode resources."""
+    mappings = template['Mappings']
+    resources = template['Resources']
+    new_resources = {}
+    for resource_name, resource in resources.items():
+        try:
+            explode_data = resource['Metadata']['Explode']
+        except KeyError:
+            # This resource does not have Explode metadata, so copy it verbatim
+            # and move on
+            new_resources[resource_name] = resource
+            continue
+        try:
+            explode_map = explode_data['Map']
+            explode_map_data = mappings[explode_map]
+        except KeyError:
+            # This resource refers to a mapping entry which doesn't exist, so
+            # fail
+            print('Unable to find mapping for exploding resource {}'.format(resource_name))
+            raise
+        resource_instances = explode_map_data.keys()
+        for resource_instance in resource_instances:
+            new_resource = walk_resource(resource, explode_map_data[resource_instance])
+            if 'ResourceName' in explode_map_data[resource_instance]:
+                new_resource_name = explode_map_data[resource_instance]['ResourceName']
+            else:
+                new_resource_name = resource_name + resource_instance
+            new_resources[new_resource_name] = new_resource
+    template['Resources'] = new_resources
+    return template
+
+
+def handler(event, _context):
+    """Handle invocation in Lambda (when CloudFormation processes the Macro)"""
+    fragment = event["fragment"]
+    status = "success"
+
+    try:
+        fragment = handle_transform(event["fragment"])
+    except:
+        status = "failure"
+
+    return {
+        "requestId": event["requestId"],
+        "status": status,
+        "fragment": fragment,
+    }
+
+
+if __name__ == "__main__":
+    """
+    If run from the command line, parse the file specified and output it
+    This is quite naive; CF YAML tags like !GetAtt will break it (as will
+    !Explode, but you can hide that in a string. Probably best to use JSON.
+    Releatedly, always outputs JSON.
+    """
+    if len(sys.argv) == 2:
+        import json
+        filename = sys.argv[1]
+        if filename.endswith(".yml") or filename.endswith(".yaml"):
+            try:
+                import yaml
+            except ImportError:
+                print("Please install PyYAML to test yaml templates")
+                sys.exit(1)
+            with open(filename, 'r') as file_handle:
+                loaded_fragment = yaml.safe_load(file_handle)
+        elif filename.endswith(".json"):
+            with open(sys.argv[1], 'r') as file_handle:
+                loaded_fragment = json.load(file_handle)
+        else:
+            print("Test file needs to end .yaml, .yml or .json")
+            sys.exit(1)
+        new_fragment = handle_transform(loaded_fragment)
+        print(json.dumps(new_fragment))

--- a/aws/services/CloudFormation/MacrosExamples/Explode/macro.yml
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/macro.yml
@@ -1,0 +1,15 @@
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  MacroFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: python3.7
+      CodeUri: lambda
+      Handler: explode.handler
+
+  Macro:
+    Type: AWS::CloudFormation::Macro
+    Properties:
+      Name: Explode
+      FunctionName: !GetAtt MacroFunction.Arn

--- a/aws/services/CloudFormation/MacrosExamples/Explode/test.yml
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/test.yml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: Explode
+Mappings:
+  BucketMap:
+    Monthly:
+      ResourceName: MyThirtyDayBucket
+      Retention: 30
+    Yearly:
+      Retention: 365
+
+Resources:
+  Bucket:
+    Metadata:
+      Explode:
+        Map: BucketMap
+    Type: AWS::S3::Bucket
+    Properties:
+      LifecycleConfiguration:
+        Rules:
+          -
+            ExpirationInDays: "!Explode Retention"
+            Status: Enabled

--- a/aws/services/CloudFormation/MacrosExamples/Explode/test.yml
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/test.yml
@@ -10,9 +10,7 @@ Mappings:
 
 Resources:
   Bucket:
-    Metadata:
-      Explode:
-        Map: BucketMap
+    ExplodeMap: BucketMap
     Type: AWS::S3::Bucket
     Properties:
       LifecycleConfiguration:
@@ -20,3 +18,5 @@ Resources:
           -
             ExpirationInDays: "!Explode Retention"
             Status: Enabled
+  NonExplodingBucket:
+    Type: AWS::S3::Bucket


### PR DESCRIPTION
*Description of changes:*

This adds an example CFN Macro, "Explode", which uses values in a `Mapping` to generate multiple copies of a template Resource. It is similar to the Count Macro, except that you can provide different values to be used in each copy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
