### PR TITLE
Fix typo numberic to numeric

### DIFF
--- a/community/services/Lambda/LambdaSample.yaml
+++ b/community/services/Lambda/LambdaSample.yaml
@@ -5,12 +5,12 @@ Parameters:
     Type: String
     Description: Name of an environment. 'dev', 'staging', 'prod' and any name.
     AllowedPattern: ^.*[^0-9]$
-    ConstraintDescription: Must end with non numberic character.
+    ConstraintDescription: Must end with non numeric character.
   LambdaHandlerPath:  
     Type: String
     Description: Path of an Lambda Handler. 
     AllowedPattern: ^.*[^0-9]$
-    ConstraintDescription: Must end with non numberic character.
+    ConstraintDescription: Must end with non numeric character.
 Outputs:
   LambdaRoleARN:
     Description: Role for Lambda execution.


### PR DESCRIPTION
*Description of changes:* Small typo `numberic` instead of `numeric`
