### PR TITLE
update ap-northeast-1 az b to c

### DIFF
--- a/aws/services/VPC/VPC_With_Managed_NAT_And_Private_Subnet.yaml
+++ b/aws/services/VPC/VPC_With_Managed_NAT_And_Private_Subnet.yaml
@@ -29,7 +29,7 @@
     # different AZ to be chosen.
     AZRegions:
       ap-northeast-1:
-        AZs: ["a", "b"]
+        AZs: ["a", "c"]
       ap-northeast-2:
         AZs: ["a", "b"]
       ap-south-1:


### PR DESCRIPTION
# Issue description

AZ **b** does not exist in the ap-northeast-1 region.
This can be confirm with the DescribeAvailabilityZones API.

DescribeAvailabilityZones - Amazon Elastic Compute Cloud  
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html

describe-availability-zones — AWS CLI 1.16.252 Command Reference  
https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-availability-zones.html

```bash
$ aws --region ap-northeast-1 ec2 describe-availability-zones
{
    "AvailabilityZones": [
        {
            "State": "available",
            "Messages": [],
            "RegionName": "ap-northeast-1",
            "ZoneName": "ap-northeast-1a",
            "ZoneId": "apne1-az4"
        },
        {
            "State": "available",
            "Messages": [],
            "RegionName": "ap-northeast-1",
            "ZoneName": "ap-northeast-1c",
            "ZoneId": "apne1-az1"
        },
        {
            "State": "available",
            "Messages": [],
            "RegionName": "ap-northeast-1",
            "ZoneName": "ap-northeast-1d",
            "ZoneId": "apne1-az2"
        }
    ]
}
```

# Description of changes:

Changed **b** of mapping ap-northeast-1 AZs to **c**.
You all can now successfully create a CloudFormation stack using this template at ap-northeast-1.

I am a pull request beginner.
If you need additional information for check this pull request, please let me know.
