### PR TITLE
Cross AWS account CodePipeline deployment

### DIFF
--- a/community/solutions/CrossAccountCodePipeline/codecommit.yaml
+++ b/community/solutions/CrossAccountCodePipeline/codecommit.yaml
@@ -1,0 +1,54 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: Allow CodePipeline (on a different AWS Account) to use an existing CodeCommit repository (from this account) under CodePipeline source stage.
+
+Parameters:
+  CodePipelineAccount:
+    Description: AWS AccountNumber hosting AWS CodePipeline
+    Type: Number
+  CMKARN:
+    Description: ARN of the KMS CMK creates in CodePipeline account
+    Type: String
+
+Conditions:
+  HasCMKARN: !Not
+    - !Equals
+      - ''
+      - !Ref 'CMKARN'
+
+Resources:
+  CrossAccountCodeCommitRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: CrossAccountCodeCommitRole
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              AWS: !Ref CodePipelineAccount
+            Action:
+              - sts:AssumeRole
+      Path: /
+  CodeCommitPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${AWS::StackName}-CodeCommitPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Action: codecommit:*
+          Effect: Allow
+          Resource: "*"
+        - Action: s3:*
+          Effect: Allow
+          Resource: "*"
+        - !If
+          - HasCMKARN
+          - Action: kms:*
+            Effect: Allow
+            Resource: !Ref CMKARN
+          - !Ref AWS::NoValue
+      Roles:
+        - !Ref CrossAccountCodeCommitRole

--- a/community/solutions/CrossAccountCodePipeline/codepipeline.yaml
+++ b/community/solutions/CrossAccountCodePipeline/codepipeline.yaml
@@ -1,0 +1,210 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: Create CodePipeline with source stage (from CodeCommit on a different AWS Account) and Deploy using AWS Beanstalk.
+
+Parameters:
+  ApplicationName:
+    Description: AWS Beanstalk Application name
+    Type: String
+  EnvironmentName:
+    Description: AWS Beanstalk Environment name
+    Type: String
+  CodeCommitAccount:
+    Description: AWS AccountNumber hosting AWS CodeCommit
+    Type: Number
+  Repo:
+    Description: Name of the AWS CodeCommit repository
+    Type: String
+  Branch:
+    Description: CodeCommit Repository Branch Name
+    Type: String
+
+Resources:
+  KMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Used by Assumed Roles in CodeCommit & CodePipeline account to Encrypt/Decrypt code
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: !Ref AWS::StackName
+        Statement:
+          -
+            Sid: Allows admin of the key
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action:
+              - "kms:*"
+            Resource: "*"
+          -
+            Sid: Allow use of the key for CodePipeline
+            Effect: Allow
+            Principal:
+              AWS:
+                - !Sub arn:aws:iam::${CodeCommitAccount}:role/CrossAccountCodeCommitRole
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+  KMSAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub alias/codepipeline-crossaccounts
+      TargetKeyId: !Ref KMSKey
+  S3BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ArtifactS3Bucket
+      PolicyDocument:
+        Statement:
+          -
+            Action:
+              - s3:*
+            Effect: Allow
+            Resource:
+              - !Sub arn:aws:s3:::${ArtifactS3Bucket}
+              - !Sub arn:aws:s3:::${ArtifactS3Bucket}/*
+            Principal:
+              AWS:
+                - !Sub arn:aws:iam::${CodeCommitAccount}:role/CrossAccountCodeCommitRole
+                - !GetAtt 'CodeBuildServiceRole.Arn'
+                - !GetAtt 'CodePipelineServiceRole.Arn'
+  ArtifactS3Bucket:
+    Properties:
+      VersioningConfiguration:
+        Status: Enabled
+    DeletionPolicy: Retain
+    Type: AWS::S3::Bucket
+  CodeBuild:
+    Properties:
+      EncryptionKey: !GetAtt 'KMSKey.Arn'
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        PrivilegedMode: true
+        Image: aws/codebuild/standard:2.0
+        Type: LINUX_CONTAINER
+      Cache:
+        Type: LOCAL
+        Modes:
+          - LOCAL_SOURCE_CACHE
+      ServiceRole: !GetAtt 'CodeBuildServiceRole.Arn'
+      Source:
+        Type: CODEPIPELINE
+    Type: AWS::CodeBuild::Project
+  CodeBuildServiceRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AdministratorAccess
+      Path: /service-role/
+    Type: AWS::IAM::Role
+  CodePipeline:
+    Properties:
+      Name: !Ref 'AWS::StackName'
+      ArtifactStore:
+        Location: !Ref 'ArtifactS3Bucket'
+        EncryptionKey:
+          Id: !GetAtt 'KMSKey.Arn'
+          Type: KMS
+        Type: S3
+      RestartExecutionOnUpdate: false
+      RoleArn: !GetAtt 'CodePipelineServiceRole.Arn'
+      Stages:
+        - Actions:
+            - ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Provider: CodeCommit
+                Version: '1'
+              Configuration:
+                RepositoryName: !Ref 'Repo'
+                BranchName: !Ref 'Branch'
+                PollForSourceChanges: true
+              Name: GetCodebase
+              OutputArtifacts:
+                - Name: ApplicationSource
+              RoleArn: !Sub arn:aws:iam::${CodeCommitAccount}:role/CrossAccountCodeCommitRole
+              RunOrder: 1
+          Name: GetSource
+        - Actions:
+            - ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: '1'
+              Configuration:
+                ProjectName: !Ref 'CodeBuild'
+              InputArtifacts:
+                - Name: ApplicationSource
+              Name: Build
+              OutputArtifacts:
+                - Name: BuildArtifact
+              RunOrder: 1
+          Name: Build
+        - Actions:
+            - ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Provider: ElasticBeanstalk
+                Version: '1'
+              Configuration:
+                ApplicationName: !Ref 'ApplicationName'
+                EnvironmentName: !Ref 'EnvironmentName'
+              InputArtifacts:
+                - Name: BuildArtifact
+              Name: Deploy
+              RunOrder: 1
+          Name: Deploy
+    Type: AWS::CodePipeline::Pipeline
+  CodePipelineServiceRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codepipeline.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/AWSCodePipelineFullAccess
+        - arn:aws:iam::aws:policy/AWSElasticBeanstalkFullAccess
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - kms:Decrypt
+                Effect: Allow
+                Resource: '*'
+              - Action:
+                  - codebuild:BatchGetBuilds
+                  - codebuild:StartBuild
+                Effect: Allow
+                Resource: '*'
+              - Action:
+                  - sts:AssumeRole
+                Effect: Allow
+                Resource: !Sub arn:aws:iam::${CodeCommitAccount}:role/CrossAccountCodeCommitRole
+            Version: '2012-10-17'
+          PolicyName: !Join
+            - '-'
+            - - CodePipeline
+              - !Ref 'AWS::StackName'
+    Type: AWS::IAM::Role
+
+Outputs:
+  CMK:
+    Value: !GetAtt 'KMSKey.Arn'

--- a/community/solutions/README.md
+++ b/community/solutions/README.md
@@ -1,0 +1,14 @@
+# Introduction
+Create CodePipeline by separating CodeCommit & CodePipeline under its own Account.
+
+# PreRequisites
+  #### 1. At least 2 separate AWS Accounts
+        - Account A => One Account holding an existing CodeCommit Repository
+        - Account B => Where CodePipeline will be created
+  #### 2. Beanstalk Application hosted in `Account B`
+
+# Installation Steps
+1. Deploy `codecommit.yaml` into `Account A`. Make sure to leave `CMKARN` Parameter blank.
+2. Deploy `codepipeline.yaml` into `Account B`. All Parameters are compulsory.
+3. Update `CodeCommit` Stack (deployed in #1) by adding `CMKARN` Parameter (from `CodePipeline` CFN output in #2)
+4. Deploy changes by releasing changes in CodePipeline Console.


### PR DESCRIPTION
Create CodePipeline by separating CodeCommit & CodePipeline under its own Account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
