### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/aws/services/IoT/lambda-iot-topicrule.yml
+++ b/aws/services/IoT/lambda-iot-topicrule.yml
@@ -68,7 +68,7 @@ Resources:
   MyLambda:
     Type: AWS::Lambda::Function
     Properties:
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/community/solutions/StaticWebSiteWithPipeline/stacks/functions.json
+++ b/community/solutions/StaticWebSiteWithPipeline/stacks/functions.json
@@ -60,7 +60,7 @@
               "Handler" : "requestCertificate.handler",
               "MemorySize" : 128,
               "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-              "Runtime" : "nodejs8.10",
+              "Runtime" : "nodejs10.x",
               "Timeout" : 10
             }
         },
@@ -73,7 +73,7 @@
               "Handler" : "approveCertificate.handler",
               "MemorySize" : 128,
               "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-              "Runtime" : "nodejs8.10",
+              "Runtime" : "nodejs10.x",
               "Timeout" : 10
             }
         },
@@ -86,7 +86,7 @@
               "Handler" : "checkCertificateApproval.handler",
               "MemorySize" : 128,
               "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-              "Runtime" : "nodejs8.10",
+              "Runtime" : "nodejs10.x",
               "Timeout" : 180
             }
         },
@@ -99,7 +99,7 @@
             "Handler" : "getHostedZoneName.handler",
             "MemorySize" : 128,
             "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime" : "nodejs8.10",
+            "Runtime" : "nodejs10.x",
             "Timeout" : 10
           }
         },
@@ -112,7 +112,7 @@
             "Handler" : "clearBuckets.handler",
             "MemorySize" : 128,
             "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime" : "nodejs8.10",
+            "Runtime" : "nodejs10.x",
             "Timeout" : 10
           }
         }


### PR DESCRIPTION
CloudFormation templates in aws-cloudformation-templates have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.