### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/aws/solutions/CloudFrontCustomOriginLambda@Edge/CloudFront.yaml
+++ b/aws/solutions/CloudFrontCustomOriginLambda@Edge/CloudFront.yaml
@@ -730,7 +730,7 @@ Resources:
               }];
               callback(null, response);
             };
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
 
 # LAMBDA@EDGE VERSION VERSION
   LambdaEdgeVersion:
@@ -766,7 +766,7 @@ Resources:
               return response.send(event, context, response.FAILED, e);
             });
           };
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
 
 
 Outputs:


### PR DESCRIPTION
CloudFormation templates in aws-cloudformation-templates have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.