### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/community/services/Lambda/LambdaSample.yaml
+++ b/community/services/Lambda/LambdaSample.yaml
@@ -59,8 +59,8 @@ Resources:
     Properties:
       FunctionName:
         Fn::Sub: lambda-function-${EnvName}
-      Description: LambdaFunctioni of nodejs4.3.
-      Runtime: nodejs4.3
+      Description: LambdaFunctioni of nodejs10.x.
+      Runtime: nodejs10.x
       Code:
         ZipFile:
           "exports.handler = function(event, context){\n

--- a/community/services/Lambda/SAM/template.yml
+++ b/community/services/Lambda/SAM/template.yml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Events:
         GetResource:
           Type: Api


### PR DESCRIPTION
CloudFormation templates in aws-cloudformation-templates have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.