### PR TITLE
Correct DelaySeconds Description  parameter

### DIFF
--- a/aws/services/SQS/SQSFIFOQueue.json
+++ b/aws/services/SQS/SQSFIFOQueue.json
@@ -16,7 +16,7 @@
       "Type": "String"
     },
     "DelaySeconds": {
-      "Description": "The time in seconds for which the delivery of all messages in the queue is delayed. You can specify an integer value of 0 to 900. The default value is 0.",
+      "Description": "The time in seconds for which the delivery of all messages in the queue is delayed. You can specify an integer value of 0 to 900. The default value is 5.",
       "Type": "Number",
       "Default": "5"
     },

--- a/aws/services/SQS/SQSFIFOQueue.json
+++ b/aws/services/SQS/SQSFIFOQueue.json
@@ -16,7 +16,7 @@
       "Type": "String"
     },
     "DelaySeconds": {
-      "Description": "The Id of the AMI you wish to launch the instance from.",
+      "Description": "The time in seconds for which the delivery of all messages in the queue is delayed. You can specify an integer value of 0 to 900. The default value is 0.",
       "Type": "Number",
       "Default": "5"
     },


### PR DESCRIPTION
*Issue #249

*Description of changes:*
Change the JSON Description parameter for "DelaySeconds" in [SQSFIFOQueue.json](https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services/SQS/SQSFIFOQueue.json). This description was found in the Cloud formation [AWS::SQS::Queue User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
