### PR TITLE
remove request module dependency

### DIFF
--- a/aws/solutions/lambda-backed-cloudformation-custom-resources/get_vpc_main_route_table_id/RouteTable.template
+++ b/aws/solutions/lambda-backed-cloudformation-custom-resources/get_vpc_main_route_table_id/RouteTable.template
@@ -57,7 +57,7 @@ Resources:
       Code:
         S3Bucket: !Ref Bucket
         S3Key: !Ref Key
-      Runtime: python3.6
+      Runtime: python3.8
       Timeout: 50
   Lambdatrigger:
     Type: 'Custom::RouteTableLambda'

--- a/aws/solutions/lambda-backed-cloudformation-custom-resources/get_vpc_main_route_table_id/Routetable.py
+++ b/aws/solutions/lambda-backed-cloudformation-custom-resources/get_vpc_main_route_table_id/Routetable.py
@@ -12,7 +12,7 @@ ec2 = boto3.client('ec2')
 
 
 def lambda_handler(event, context):
-    print("Received event: " + json.dumps(event, indent=2))
+    print("Received event: " + json.dumps(event))
     responseData = {}
     try:
         if event['RequestType'] == 'Delete':

--- a/aws/solutions/lambda-backed-cloudformation-custom-resources/get_vpc_main_route_table_id/Routetable.py
+++ b/aws/solutions/lambda-backed-cloudformation-custom-resources/get_vpc_main_route_table_id/Routetable.py
@@ -20,13 +20,13 @@ def lambda_handler(event, context):
         elif event['RequestType'] == 'Create':
             print("Request Type:", event['RequestType'])
             VPCID = event['ResourceProperties']['VPCID']
-            RouteTableID = get_vpc(VPCID)
+            RouteTableID = get_rtb(VPCID)
             responseData = {'RoutetableID': RouteTableID}
             print("Sending response to custom resource")
         elif event['RequestType'] == 'Update':
             print("Request Type:", event['RequestType'])
             VPCID = event['ResourceProperties']['VPCID']
-            RouteTableID = get_vpc(VPCID)
+            RouteTableID = get_rtb(VPCID)
             responseData = {'RoutetableID': RouteTableID}
             print("Sending response to custom resource")
         responseStatus = 'SUCCESS'
@@ -37,7 +37,7 @@ def lambda_handler(event, context):
     send(event, context, responseStatus, responseData)
 
 
-def get_vpc(VPCID):
+def get_rtb(VPCID):
     response = ec2.describe_route_tables(
         Filters=[
             {

--- a/aws/solutions/lambda-backed-cloudformation-custom-resources/get_vpc_main_route_table_id/Routetable.py
+++ b/aws/solutions/lambda-backed-cloudformation-custom-resources/get_vpc_main_route_table_id/Routetable.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 import json
 import boto3
 import urllib
-from botocore.vendored import requests
 
 SUCCESS = "SUCCESS"
 FAILED = "FAILED"
@@ -74,9 +73,9 @@ def send(event, context, responseStatus, responseData, physicalResourceId=None, 
         'content-length': str(len(json_responseBody))
     }
     try:
-        response = requests.put(responseUrl,
-                                data=json_responseBody,
-                                headers=headers)
-        print("Status code: " + response.reason)
+        request = urllib.request.Request(
+            responseUrl, method="PUT", data=json_responseBody.encode('utf-8'), headers=headers)
+        with urllib.request.urlopen(request) as response:
+            print("Status code: " + response.reason)
     except Exception as e:
         print("send(..) failed executing requests.put(..): " + str(e))

--- a/aws/solutions/lambda-backed-cloudformation-custom-resources/get_vpc_main_route_table_id/Routetable.py
+++ b/aws/solutions/lambda-backed-cloudformation-custom-resources/get_vpc_main_route_table_id/Routetable.py
@@ -10,24 +10,25 @@ FAILED = "FAILED"
 print('Loading function')
 ec2 = boto3.client('ec2')
 
+
 def lambda_handler(event, context):
     print("Received event: " + json.dumps(event, indent=2))
-    responseData={}
+    responseData = {}
     try:
         if event['RequestType'] == 'Delete':
-            print("Request Type:",event['RequestType'])
+            print("Request Type:", event['RequestType'])
             print("Delete Request - No Physical resources to delete")
         elif event['RequestType'] == 'Create':
-            print("Request Type:",event['RequestType'])
-            VPCID=event['ResourceProperties']['VPCID']
-            RouteTableID=get_vpc(VPCID)
-            responseData={'RoutetableID':RouteTableID}
+            print("Request Type:", event['RequestType'])
+            VPCID = event['ResourceProperties']['VPCID']
+            RouteTableID = get_vpc(VPCID)
+            responseData = {'RoutetableID': RouteTableID}
             print("Sending response to custom resource")
         elif event['RequestType'] == 'Update':
-            print("Request Type:",event['RequestType'])
-            VPCID=event['ResourceProperties']['VPCID']
-            RouteTableID=get_vpc(VPCID)
-            responseData={'RoutetableID':RouteTableID}
+            print("Request Type:", event['RequestType'])
+            VPCID = event['ResourceProperties']['VPCID']
+            RouteTableID = get_vpc(VPCID)
+            responseData = {'RoutetableID': RouteTableID}
             print("Sending response to custom resource")
         responseStatus = 'SUCCESS'
     except Exception as e:
@@ -36,23 +37,25 @@ def lambda_handler(event, context):
         responseData = {'Failure': 'Something bad happened.'}
     send(event, context, responseStatus, responseData)
 
+
 def get_vpc(VPCID):
-    response = ec2.describe_route_tables (
-      Filters=[
-        {
-          'Name': 'association.main',
-          'Values': [ 'true' ]
-        },
-        {
-          'Name': 'vpc-id',
-          'Values': [ VPCID ]
-        }
-      ]
+    response = ec2.describe_route_tables(
+        Filters=[
+            {
+                'Name': 'association.main',
+                'Values': ['true']
+            },
+            {
+                'Name': 'vpc-id',
+                'Values': [VPCID]
+            }
+        ]
     )
     print("Printing the VPC Route Table ID ....")
-    RouteTableID=response['RouteTables'][0]['RouteTableId']
+    RouteTableID = response['RouteTables'][0]['RouteTableId']
     print(RouteTableID)
     return RouteTableID
+
 
 def send(event, context, responseStatus, responseData, physicalResourceId=None, noEcho=False):
     responseUrl = event['ResponseURL']
@@ -67,8 +70,8 @@ def send(event, context, responseStatus, responseData, physicalResourceId=None, 
     json_responseBody = json.dumps(responseBody)
     print("Response body:\n" + json_responseBody)
     headers = {
-        'content-type' : '',
-        'content-length' : str(len(json_responseBody))
+        'content-type': '',
+        'content-length': str(len(json_responseBody))
     }
     try:
         response = requests.put(responseUrl,


### PR DESCRIPTION
Recently, I tried `VPC Main/Default Route Table Lookup Custom Resource`  sample.

It worked well, but it says the requests module in botocore library will be deprecated very soon.

```
/var/runtime/botocore/vendored/requests/api.py:64: DeprecationWarning: You are using the put() function from 'botocore.vendored.requests'.  This dependency was removed from Botocore and will be removed from Lambda after 2020/03/31. https://aws.amazon.com/blogs/developer/removing-the-vendored-version-of-requests-from-botocore/. Install the requests package, 'import requests' directly, and use the requests.put() function instead.
```

So, I changed the script to use built-in urllib library instead to make it easier to bundle function.

P.S. 
I really want VPC resource has default route table ID as an attribute to make our lives easier...