### PR TITLE
Update ubuntu16.04LTS_cfn-hup.template

### DIFF
--- a/aws/solutions/HelperNonAmaznAmi/ubuntu16.04LTS_cfn-hup.template
+++ b/aws/solutions/HelperNonAmaznAmi/ubuntu16.04LTS_cfn-hup.template
@@ -118,7 +118,7 @@
              "apt-get install -y python-setuptools\n",
              "mkdir -p /opt/aws/bin\n",
              "wget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz\n",
-             "easy_install --script-dir /opt/aws/bin aws-cfn-bootstrap-latest.tar.gz\n",
+             "python -m easy_install --script-dir /opt/aws/bin aws-cfn-bootstrap-latest.tar.gz\n",
               "/opt/aws/bin/cfn-init -v ",
              "         --stack ", { "Ref" : "AWS::StackName" },
              "         --resource EC2Instance ",


### PR DESCRIPTION
Fix up issue: https://github.com/awslabs/aws-cloudformation-templates/issues/272

*Issue #, if available:*
https://github.com/awslabs/aws-cloudformation-templates/issues/272

*Description of changes:*
From Ubuntu 18, there will be no easy_install command, but we could use the easy_install module in python command, then this template will be suitable for both the Ubuntu 14,16 and 18. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
