### PR TITLE
Add CloudFormation templates for variations in s3 cross account access buckets and policies

### DIFF
--- a/aws/services/S3/s3-bucket-and-policy-for-caa-delete-retention-v1.yaml
+++ b/aws/services/S3/s3-bucket-and-policy-for-caa-delete-retention-v1.yaml
@@ -1,11 +1,16 @@
 AWSTemplateFormatVersion: 2010-09-09
+Description: 'AWS CloudFormation Sample Template:
+  Sample template which will create an s3 bucket with deletion retention
+  enabled and a bucket policy to enable cross account acccess. The template
+  requires you to provide an AWS account ID to provide cross account access to,
+  and a globally unique name for an s3 bucket.'
 Parameters:
   BucketName:
     Type: String
     Description: 'The name of the S3 Bucket to create, make this unique'
   PublisherAccountID:
     Type: String
-    Description: 'The account ID of the Publisher with whom you are sharing access'    
+    Description: 'The AWS account ID with whom you are sharing access'
 Resources:
   S3BUCKET:
     Type: 'AWS::S3::Bucket'

--- a/aws/services/S3/s3-bucket-and-policy-for-caa-delete-retention-v1.yaml
+++ b/aws/services/S3/s3-bucket-and-policy-for-caa-delete-retention-v1.yaml
@@ -1,0 +1,41 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  BucketName:
+    Type: String
+    Description: 'The name of the S3 Bucket to create, make this unique'
+  PublisherAccountID:
+    Type: String
+    Description: 'The account ID of the Publisher with whom you are sharing access'    
+Resources:
+  S3BUCKET:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Ref BucketName
+    DeletionPolicy: Retain
+  S3BUCKETPOL:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref S3BUCKET
+      PolicyDocument:
+        Id: CrossAccessPolicy
+        Version: "2012-10-17"
+        Statement:
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:ListBucket"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${S3BUCKET}'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:GetObject"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${S3BUCKET}/*'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+Outputs:
+  Bucket:
+    Description: S3 Bucket Name
+    Value: !Ref S3BUCKET
+  BucketPolicy:
+    Description: S3 Bucket Policy Name
+    Value: !Ref S3BUCKETPOL

--- a/aws/services/S3/s3-bucket-and-policy-for-caa-secure-transport-v1.yaml
+++ b/aws/services/S3/s3-bucket-and-policy-for-caa-secure-transport-v1.yaml
@@ -1,11 +1,16 @@
 AWSTemplateFormatVersion: 2010-09-09
+Description: 'AWS CloudFormation Sample Template:
+  Sample template which will create an s3 bucket with a bucket policy enforcing
+  secure transport and enabling cross account acccess. The template requires you
+  to provide an AWS account ID to provide cross account access to, and a globally
+  unique name for an s3 bucket.'
 Parameters:
   BucketName:
     Type: String
     Description: 'The name of the S3 Bucket to create, make this unique'
   PublisherAccountID:
     Type: String
-    Description: 'The account ID of the Publisher with whom you are sharing access'    
+    Description: 'The AWS account ID with whom you are sharing access'    
 Resources:
   S3BUCKET:
     Type: 'AWS::S3::Bucket'

--- a/aws/services/S3/s3-bucket-and-policy-for-caa-secure-transport-v1.yaml
+++ b/aws/services/S3/s3-bucket-and-policy-for-caa-secure-transport-v1.yaml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  BucketName:
+    Type: String
+    Description: 'The name of the S3 Bucket to create, make this unique'
+  PublisherAccountID:
+    Type: String
+    Description: 'The account ID of the Publisher with whom you are sharing access'    
+Resources:
+  S3BUCKET:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Ref BucketName
+  S3BUCKETPOL:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref S3BUCKET
+      PolicyDocument:
+        Id: CrossAccessPolicy
+        Version: "2012-10-17"
+        Statement:
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:ListBucket"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${S3BUCKET}'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:GetObject"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${S3BUCKET}/*'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+          - Sid: HttpsOnly
+            Action: '*'
+            Effect: Deny
+            Resource: !Sub arn:aws:s3:::${BucketName}/*
+            Principal: '*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
+Outputs:
+  Bucket:
+    Description: S3 Bucket Name
+    Value: !Ref S3BUCKET
+  BucketPolicy:
+    Description: S3 Bucket Policy Name
+    Value: !Ref S3BUCKETPOL

--- a/aws/services/S3/s3-bucket-and-policy-for-caa-sse-v1.yaml
+++ b/aws/services/S3/s3-bucket-and-policy-for-caa-sse-v1.yaml
@@ -1,0 +1,44 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  BucketName:
+    Type: String
+    Description: 'The name of the S3 Bucket to create, make this unique'
+  PublisherAccountID:
+    Type: String
+    Description: 'The account ID of the Publisher with whom you are sharing access'    
+Resources:
+  S3BUCKET:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Ref BucketName
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+  S3BUCKETPOL:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref S3BUCKET
+      PolicyDocument:
+        Id: CrossAccessPolicy
+        Version: "2012-10-17"
+        Statement:
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:ListBucket"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${S3BUCKET}'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:GetObject"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${S3BUCKET}/*'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+Outputs:
+  Bucket:
+    Description: S3 Bucket Name
+    Value: !Ref S3BUCKET
+  BucketPolicy:
+    Description: S3 Bucket Policy Name
+    Value: !Ref S3BUCKETPOL

--- a/aws/services/S3/s3-bucket-and-policy-for-caa-sse-v1.yaml
+++ b/aws/services/S3/s3-bucket-and-policy-for-caa-sse-v1.yaml
@@ -1,11 +1,16 @@
 AWSTemplateFormatVersion: 2010-09-09
+Description: 'AWS CloudFormation Sample Template:
+  Sample template which will create an s3 bucket with server side encryption
+  enabled and a bucket policy to enable cross account acccess. The template
+  requires you to provide an AWS account ID to provide cross account access to,
+  and a globally unique name for an s3 bucket.'
 Parameters:
   BucketName:
     Type: String
     Description: 'The name of the S3 Bucket to create, make this unique'
   PublisherAccountID:
     Type: String
-    Description: 'The account ID of the Publisher with whom you are sharing access'    
+    Description: 'The AWS account ID with whom you are sharing access'
 Resources:
   S3BUCKET:
     Type: 'AWS::S3::Bucket'

--- a/aws/services/S3/s3-bucket-and-policy-for-caa-v1.yaml
+++ b/aws/services/S3/s3-bucket-and-policy-for-caa-v1.yaml
@@ -1,11 +1,15 @@
 AWSTemplateFormatVersion: 2010-09-09
+Description: 'AWS CloudFormation Sample Template:
+  Sample template which will create an s3 bucket with a bucket policy to enable
+  cross account acccess. The template requires you to provide an AWS account ID
+  to provide cross account access to, and a globally unique name for an s3 bucket.'
 Parameters:
   BucketName:
     Type: String
     Description: 'The name of the S3 Bucket to create, make this unique'
   PublisherAccountID:
     Type: String
-    Description: 'The account ID of the Publisher with whom you are sharing access'    
+    Description: 'The AWS account ID with whom you are sharing access'
 Resources:
   S3BUCKET:
     Type: 'AWS::S3::Bucket'

--- a/aws/services/S3/s3-bucket-and-policy-for-caa-v1.yaml
+++ b/aws/services/S3/s3-bucket-and-policy-for-caa-v1.yaml
@@ -1,0 +1,40 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  BucketName:
+    Type: String
+    Description: 'The name of the S3 Bucket to create, make this unique'
+  PublisherAccountID:
+    Type: String
+    Description: 'The account ID of the Publisher with whom you are sharing access'    
+Resources:
+  S3BUCKET:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Ref BucketName
+  S3BUCKETPOL:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref S3BUCKET
+      PolicyDocument:
+        Id: CrossAccessPolicy
+        Version: "2012-10-17"
+        Statement:
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:ListBucket"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${S3BUCKET}'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:GetObject"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${S3BUCKET}/*'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+Outputs:
+  Bucket:
+    Description: S3 Bucket Name
+    Value: !Ref S3BUCKET
+  BucketPolicy:
+    Description: S3 Bucket Policy Name
+    Value: !Ref S3BUCKETPOL

--- a/aws/services/S3/s3-bucket-and-policy-for-caa-versioning-v1.yaml
+++ b/aws/services/S3/s3-bucket-and-policy-for-caa-versioning-v1.yaml
@@ -1,0 +1,42 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  BucketName:
+    Type: String
+    Description: 'The name of the S3 Bucket to create, make this unique'
+  PublisherAccountID:
+    Type: String
+    Description: 'The account ID of the Publisher with whom you are sharing access'    
+Resources:
+  S3BUCKET:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Ref BucketName
+      VersioningConfiguration:
+        Status: Enabled
+  S3BUCKETPOL:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref S3BUCKET
+      PolicyDocument:
+        Id: CrossAccessPolicy
+        Version: "2012-10-17"
+        Statement:
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:ListBucket"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${S3BUCKET}'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:GetObject"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${S3BUCKET}/*'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+Outputs:
+  Bucket:
+    Description: S3 Bucket Name
+    Value: !Ref S3BUCKET
+  BucketPolicy:
+    Description: S3 Bucket Policy Name
+    Value: !Ref S3BUCKETPOL

--- a/aws/services/S3/s3-bucket-and-policy-for-caa-versioning-v1.yaml
+++ b/aws/services/S3/s3-bucket-and-policy-for-caa-versioning-v1.yaml
@@ -1,11 +1,16 @@
 AWSTemplateFormatVersion: 2010-09-09
+Description: 'AWS CloudFormation Sample Template:
+  Sample template which will create an s3 bucket with versioning
+  enabled and a bucket policy to enable cross account acccess. The template
+  requires you to provide an AWS account ID to provide cross account access to,
+  and a globally unique name for an s3 bucket.'
 Parameters:
   BucketName:
     Type: String
     Description: 'The name of the S3 Bucket to create, make this unique'
   PublisherAccountID:
     Type: String
-    Description: 'The account ID of the Publisher with whom you are sharing access'    
+    Description: 'The AWS account ID with whom you are sharing access'
 Resources:
   S3BUCKET:
     Type: 'AWS::S3::Bucket'

--- a/aws/services/S3/s3-bucket-policy-for-caa-secure-transport-v1.yaml
+++ b/aws/services/S3/s3-bucket-policy-for-caa-secure-transport-v1.yaml
@@ -1,0 +1,44 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  BucketName:
+    Type: String
+    Description: 'The existing S3 Bucket to create the policy for'
+  PublisherAccountID:
+    Type: String
+    Description: 'The account ID of the Publisher with whom you are sharing access'    
+Resources:
+  S3BUCKETPOL:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref BucketName
+      PolicyDocument:
+        Id: CrossAccessPolicy
+        Version: "2012-10-17"
+        Statement:
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:ListBucket"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${BucketName}'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:GetObject"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${BucketName}/*'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+          - Sid: HttpsOnly
+            Action: '*'
+            Effect: Deny
+            Resource: !Sub arn:aws:s3:::${BucketName}/*
+            Principal: '*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
+Outputs:
+  Bucket:
+    Description: S3 Bucket Name
+    Value: !Ref BucketName
+  BucketPolicy:
+    Description: S3 Bucket Policy Name
+    Value: !Ref S3BUCKETPOL

--- a/aws/services/S3/s3-bucket-policy-for-caa-secure-transport-v1.yaml
+++ b/aws/services/S3/s3-bucket-policy-for-caa-secure-transport-v1.yaml
@@ -1,11 +1,15 @@
 AWSTemplateFormatVersion: 2010-09-09
+Description: 'AWS CloudFormation Sample Template:
+  Sample template which will create a bucket policy to enable cross account
+  acccess. The template requires you to provide an AWS account ID to provide
+  cross account access to, and the name of the target bucket.'
 Parameters:
   BucketName:
     Type: String
     Description: 'The existing S3 Bucket to create the policy for'
   PublisherAccountID:
     Type: String
-    Description: 'The account ID of the Publisher with whom you are sharing access'    
+    Description: 'The AWS account ID with whom you are sharing access'    
 Resources:
   S3BUCKETPOL:
     Type: 'AWS::S3::BucketPolicy'

--- a/aws/services/S3/s3-bucket-policy-for-caa-v1.yaml
+++ b/aws/services/S3/s3-bucket-policy-for-caa-v1.yaml
@@ -1,11 +1,15 @@
 AWSTemplateFormatVersion: 2010-09-09
+Description: 'AWS CloudFormation Sample Template:
+  Sample template which will create a bucket policy to enable cross account
+  acccess. The template requires you to provide an AWS account ID to provide
+  cross account access to, and the name of the target bucket.'
 Parameters:
   BucketName:
     Type: String
     Description: 'The existing S3 Bucket to create the policy for'
   PublisherAccountID:
     Type: String
-    Description: 'The account ID of the Publisher with whom you are sharing access'    
+    Description: 'The AWS account ID with whom you are sharing access'
 Resources:
   S3BUCKETPOL:
     Type: 'AWS::S3::BucketPolicy'

--- a/aws/services/S3/s3-bucket-policy-for-caa-v1.yaml
+++ b/aws/services/S3/s3-bucket-policy-for-caa-v1.yaml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  BucketName:
+    Type: String
+    Description: 'The existing S3 Bucket to create the policy for'
+  PublisherAccountID:
+    Type: String
+    Description: 'The account ID of the Publisher with whom you are sharing access'    
+Resources:
+  S3BUCKETPOL:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref BucketName
+      PolicyDocument:
+        Id: CrossAccessPolicy
+        Version: "2012-10-17"
+        Statement:
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:ListBucket"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${BucketName}'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+          - Sid: CrossAccPolicyDoc
+            Action: "s3:GetObject"
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${BucketName}/*'
+            Principal:
+              AWS: !Join ['', ["arn:aws:iam::", !Ref PublisherAccountID, ":root"]]
+Outputs:
+  Bucket:
+    Description: S3 Bucket Name
+    Value: !Ref BucketName
+  BucketPolicy:
+    Description: S3 Bucket Policy Name
+    Value: !Ref S3BUCKETPOL


### PR DESCRIPTION
Added multiple CloudFormation templates for variations in s3 cross account access buckets and policies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
