### PR TITLE
VPCFlowLogs to CloudWatch and/or S3

### DIFF
--- a/aws/solutions/VPCFlowLogs/README.md
+++ b/aws/solutions/VPCFlowLogs/README.md
@@ -1,0 +1,47 @@
+# VPCFlowLogs
+
+- [VPCFlowLogs](#vpcflowlogs)
+  - [Description](#description)
+  - [Resources](#resources)
+  - [Solution Highlights](#solution-highlights)
+  - [Instructions (Individual Templates)](#instructions-individual-templates)
+  - [Instructions (Nested Stacks)](#instructions-nested-stacks)
+
+## Description
+
+This solution lets you enable Flow Logs for a VPC, and publish the flow log data to either CloudWatch Logs, S3, or both.
+
+This solution can be implemented as individual templates accordingly, or leveraging the nested stacks `main` templates.
+
+## Resources
+
+- [Publishing flow logs to CloudWatch Logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html)
+- [Publishing flow logs to Amazon S3](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html)
+
+## Solution Highlights
+
+This solution provides methods to enable VPC flow logs, as designed. This solution can also be used as a reference in creating other CloudFormation
+templates.
+
+- VPC flow log settings are parameterized, so they can be customized as needed.
+- Supports publishing VPC flow log data to `S3` using an existing S3 bucket, or having a new S3 bucket created with encryption.
+  - By default, server-side encryption with Amazon S3-managed encryption keys
+    [SSE-S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html) that uses `AES-256`.
+  - If KMS Key is provided, then server-side encryption is done with the specified KMS CMK
+    ([SSE-KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html))
+    - An option is provided to enable the use of an [S3 Bucket Key](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-bucket-key.html).
+- Supports publishing VPC flow log data to `CloudWatch Logs`
+  - Lets you set the log retention for the log group being used for VPC flow logs.
+  - By default, log group data is encrypted with CloudWatch Logs managing the server-side encryption keys.
+  - If KMS Key is provided, then server-side encryption is done with the specified
+    [KMS CMK](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)
+
+## Instructions (Individual Templates)
+
+1. Deploy [VPCFlowLogsCloudWatch.cfn.yaml](templates/VPCFlowLogsCloudWatch.cfn.yaml) template to enable VPC Flow Logs and publish data to CloudWatch
+   Logs.
+2. Deploy [VPCFlowLogsS3.cfn.yaml](templates/VPCFlowLogsS3.cfn.yaml) template to enable VPC Flow Logs and publish data to S3.
+
+## Instructions (Nested Stacks)
+
+1. Deploy [VPCFlowLogs.cfn.yaml](templates/VPCFlowLogs.cfn.yaml) template to enable VPC Flow Logs to CloudWatch Logs, S3, or both.

--- a/aws/solutions/VPCFlowLogs/templates/VPCFlowLogs.cfn.yaml
+++ b/aws/solutions/VPCFlowLogs/templates/VPCFlowLogs.cfn.yaml
@@ -1,0 +1,206 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  This template enables VPC Flow Logs to CloudWatch, S3, or both.
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Network Configuration
+        Parameters:
+          - VPCID
+      - Label:
+          default: VPC Flow Logs Configuration
+        Parameters:
+          - VPCFlowLogsLogFormat
+          - VPCFlowLogsMaxAggregationInterval
+          - VPCFlowLogsTrafficType
+      - Label:
+          default: VPC Flow Logs to CloudWatch Configuration
+        Parameters:
+          - CreateVPCFlowLogsToCloudWatch
+          - VPCFlowLogsLogGroupRetention
+          - VPCFlowLogsCloudWatchKMSKey
+      - Label:
+          default: VPC Flow Logs to S3 Configuration
+        Parameters:
+          - CreateVPCFlowLogsToS3
+          - VPCFlowLogsBucketName
+          - S3AccessLogsBucketName
+      - Label:
+          default: Templates Configuration
+        Parameters:
+          - TemplatesS3BucketName
+          - TemplatesS3BucketRegion
+    ParameterLabels:
+      CreateVPCFlowLogsToCloudWatch:
+        default: Enable VPC flow logs to CloudWatch
+      CreateVPCFlowLogsToS3:
+        default: Enable VPC flow logs to S3
+      S3AccessLogsBucketName:
+        default: S3 Access Logs Bucket Name
+      TemplatesS3BucketName:
+        default: Templates S3 Bucket Name
+      TemplatesS3BucketRegion:
+        default: Templates S3 Bucket Region
+      VPCFlowLogsBucketKeyEnabled:
+        default: VPC Flow Logs Bucket Key Enabled
+      VPCFlowLogsBucketKMSKey:
+        default: VPC Flow Logs Bucket KMS Key
+      VPCFlowLogsBucketName:
+        default: VPC Flow Logs Bucket Name
+      VPCFlowLogsCloudWatchKMSKey:
+        default: CloudWatch Logs KMS Key for VPC flow logs
+      VPCFlowLogsLogFormat:
+        default: VPC Flow Logs - Log Format
+      VPCFlowLogsLogGroupRetention:
+        default: CloudWatch log retention days for VPC flow logs
+      VPCFlowLogsMaxAggregationInterval:
+        default: VPC Flow Logs - Max Aggregation Interval
+      VPCFlowLogsTrafficType:
+        default: VPC Flow Logs - Traffic Type
+      VPCID:
+        default: VPC ID
+Parameters:
+  CreateVPCFlowLogsToCloudWatch:
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+    Description:
+      Set to true to create VPC flow logs for the VPC and publish them to CloudWatch. If false, VPC flow logs will not be created/published to
+      CloudWatch.
+    Type: String
+  CreateVPCFlowLogsToS3:
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+    Description: Set to true to create VPC flow logs for the VPC and publish them to S3. If false, VPC flow logs will not be created/published to S3.
+    Type: String
+  S3AccessLogsBucketName:
+    AllowedPattern: '^$|^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
+    ConstraintDescription:
+      S3 Access Logs bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Default: ''
+    Description:
+      (Optional) S3 Access Logs bucket name for where Amazon S3 should store server access log files. S3 Access Logs bucket name can include numbers,
+      lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Type: String
+  TemplatesS3BucketName:
+    AllowedPattern: '^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
+    ConstraintDescription:
+      Templates S3 bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Description:
+      Templates S3 bucket name for the CloudFormation templates. Templates bucket name can include numbers, lowercase letters, uppercase letters, and
+      hyphens (-). It cannot start or end with a hyphen (-).
+    Type: String
+  TemplatesS3BucketRegion:
+    Description: The AWS Region where the Templates S3 bucket (TemplatesS3BucketName) is hosted.
+    Type: String
+  VPCFlowLogsBucketKeyEnabled:
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+    Description:
+      Set to true to have Amazon S3 use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS). If false, S3 Bucket Key is not enabled.
+      Note, will only be set if KMS Key parameter, "VPCFlowLogsBucketKMSKey", was provided.
+    Type: String
+  VPCFlowLogsBucketKMSKey:
+    AllowedPattern: '^$|^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$|^arn:(aws[a-zA-Z-]*)?:kms:[a-z0-9-]+:\d{12}:key\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'
+    ConstraintDescription:
+      'Key ID example: 1234abcd-12ab-34cd-56ef-1234567890ab  Key ARN
+      examlpe:  arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab'
+    Default: ''
+    Description:
+      (Optional) KMS Key ID or ARN to use for the default encryption. If empty, server-side encryption with Amazon S3-managed encryption keys (SSE-S3)
+      will be used. Note, will only be set if S3 Bucket parameter, "VPCFlowLogsBucketName", was not provided, thus a new S3 bucket is being created.
+    Type: String
+  VPCFlowLogsBucketName:
+    AllowedPattern: '^$|^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
+    ConstraintDescription:
+      S3 bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Default: ''
+    Description:
+      (Optional) S3 bucket name where VPC Flow Log data can be published. S3 bucket name can include numbers, lowercase letters, uppercase letters,
+      and hyphens (-). It cannot start or end with a hyphen (-). If empty, a new S3 bucket will be created for VPC Flow Log data to be published.
+    Type: String
+  VPCFlowLogsCloudWatchKMSKey:
+    AllowedPattern: '^$|^arn:(aws[a-zA-Z-]*)?:kms:[a-z0-9-]+:\d{12}:key\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'
+    ConstraintDescription: 'Key ARN example:  arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab'
+    Default: ''
+    Description:
+      (Optional) KMS Key ARN to use for encrypting the VPC flow logs data. If empty, encryption is enabled with CloudWatch Logs managing the
+      server-side encryption keys.
+    Type: String
+  VPCFlowLogsLogFormat:
+    AllowedPattern: '^(\$\{[a-z-]+\})$|^((\$\{[a-z-]+\} )*\$\{[a-z-]+\})$'
+    Default:
+      '${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action}
+      ${log-status}'
+    Description:
+      The fields to include in the flow log record, in the order in which they should appear. Specify the fields using the ${field-id} format,
+      separated by spaces. Using the Default Format as the default value.
+    Type: String
+  VPCFlowLogsLogGroupRetention:
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+    Default: 14
+    Description: Number of days to retain the VPC Flow Logs in CloudWatch
+    Type: String
+  VPCFlowLogsMaxAggregationInterval:
+    AllowedValues:
+      - 60
+      - 600
+    Default: 600
+    Description:
+      The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. You can specify 60 seconds (1
+      minute) or 600 seconds (10 minutes).
+    Type: String
+  VPCFlowLogsTrafficType:
+    AllowedValues:
+      - ACCEPT
+      - ALL
+      - REJECT
+    Default: REJECT
+    Description: The type of traffic to log. You can log traffic that the resource accepts or rejects, or all traffic.
+    Type: String
+  VPCID:
+    Description: ID of the VPC (e.g., vpc-0343606e)
+    Type: AWS::EC2::VPC::Id
+Rules:
+  EnableVPCFlowLogs:
+    Assertions:
+      - Assert: !Or
+          - !Equals [!Ref CreateVPCFlowLogsToCloudWatch, 'true']
+          - !Equals [!Ref CreateVPCFlowLogsToS3, 'true']
+        AssertDescription: To enable VPC Flow Logs, you must have CreateVPCFlowLogsToCloudWatch and/or CreateVPCFlowLogsToS3 set to 'true'
+Conditions:
+  VPCFlowLogsToCloudWatchCondition: !Equals [!Ref CreateVPCFlowLogsToCloudWatch, 'true']
+  VPCFlowLogsToS3Condition: !Equals [!Ref CreateVPCFlowLogsToS3, 'true']
+Resources:
+  VPCFlowLogsCloudWatchStack:
+    Condition: VPCFlowLogsToCloudWatchCondition
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub https://${TemplatesS3BucketName}.s3.${TemplatesS3BucketRegion}.${AWS::URLSuffix}/templates/VPCFlowLogsCloudWatch.cfn.yaml
+      Parameters:
+        VPCFlowLogsCloudWatchKMSKey: !Ref VPCFlowLogsCloudWatchKMSKey
+        VPCFlowLogsLogFormat: !Ref VPCFlowLogsLogFormat
+        VPCFlowLogsLogGroupRetention: !Ref VPCFlowLogsLogGroupRetention
+        VPCFlowLogsMaxAggregationInterval: !Ref VPCFlowLogsMaxAggregationInterval
+        VPCFlowLogsTrafficType: !Ref VPCFlowLogsTrafficType
+        VPCID: !Ref VPCID
+  VPCFlowLogsS3Stack:
+    Condition: VPCFlowLogsToS3Condition
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub https://${TemplatesS3BucketName}.s3.${TemplatesS3BucketRegion}.${AWS::URLSuffix}/templates/VPCFlowLogsS3.cfn.yaml
+      Parameters:
+        S3AccessLogsBucketName: !Ref S3AccessLogsBucketName
+        VPCFlowLogsBucketKeyEnabled: !Ref VPCFlowLogsBucketKeyEnabled
+        VPCFlowLogsBucketKMSKey: !Ref VPCFlowLogsBucketKMSKey
+        VPCFlowLogsBucketName: !Ref VPCFlowLogsBucketName
+        VPCFlowLogsLogFormat: !Ref VPCFlowLogsLogFormat
+        VPCFlowLogsMaxAggregationInterval: !Ref VPCFlowLogsMaxAggregationInterval
+        VPCFlowLogsTrafficType: !Ref VPCFlowLogsTrafficType
+        VPCID: !Ref VPCID

--- a/aws/solutions/VPCFlowLogs/templates/VPCFlowLogsCloudWatch.cfn.yaml
+++ b/aws/solutions/VPCFlowLogs/templates/VPCFlowLogsCloudWatch.cfn.yaml
@@ -1,0 +1,129 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  This template enables VPC Flow Logs to CloudWatch.
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Network Configuration
+        Parameters:
+          - VPCID
+      - Label:
+          default: VPC Flow Logs Configuration
+        Parameters:
+          - VPCFlowLogsLogFormat
+          - VPCFlowLogsMaxAggregationInterval
+          - VPCFlowLogsTrafficType
+          - VPCFlowLogsLogGroupRetention
+          - VPCFlowLogsCloudWatchKMSKey
+    ParameterLabels:
+      VPCFlowLogsCloudWatchKMSKey:
+        default: CloudWatch Logs KMS Key for VPC flow logs
+      VPCFlowLogsLogFormat:
+        default: VPC Flow Logs - Log Format
+      VPCFlowLogsLogGroupRetention:
+        default: CloudWatch log retention days for VPC flow logs
+      VPCFlowLogsMaxAggregationInterval:
+        default: VPC Flow Logs - Max Aggregation Interval
+      VPCFlowLogsTrafficType:
+        default: VPC Flow Logs - Traffic Type
+      VPCID:
+        default: VPC ID
+Parameters:
+  VPCFlowLogsCloudWatchKMSKey:
+    AllowedPattern: '^$|^arn:(aws[a-zA-Z-]*)?:kms:[a-z0-9-]+:\d{12}:key\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'
+    ConstraintDescription: 'Key ARN example:  arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab'
+    Default: ''
+    Description:
+      (Optional) KMS Key ARN to use for encrypting the VPC flow logs data. If empty, encryption is enabled with CloudWatch Logs managing the
+      server-side encryption keys.
+    Type: String
+  VPCFlowLogsLogFormat:
+    AllowedPattern: '^(\$\{[a-z-]+\})$|^((\$\{[a-z-]+\} )*\$\{[a-z-]+\})$'
+    Default:
+      '${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action}
+      ${log-status}'
+    Description:
+      The fields to include in the flow log record, in the order in which they should appear. Specify the fields using the ${field-id} format,
+      separated by spaces. Using the Default Format as the default value.
+    Type: String
+  VPCFlowLogsLogGroupRetention:
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+    Default: 14
+    Description: Number of days to retain the VPC Flow Logs in CloudWatch
+    Type: String
+  VPCFlowLogsMaxAggregationInterval:
+    AllowedValues:
+      - 60
+      - 600
+    Default: 600
+    Description:
+      The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. You can specify 60 seconds (1
+      minute) or 600 seconds (10 minutes).
+    Type: String
+  VPCFlowLogsTrafficType:
+    AllowedValues:
+      - ACCEPT
+      - ALL
+      - REJECT
+    Default: REJECT
+    Description: The type of traffic to log. You can log traffic that the resource accepts or rejects, or all traffic.
+    Type: String
+  VPCID:
+    Description: ID of the VPC (e.g., vpc-0343606e)
+    Type: AWS::EC2::VPC::Id
+Conditions:
+  VPCFlowLogsCloudWatchKMSKeyCondition: !Not [!Equals [!Ref VPCFlowLogsCloudWatchKMSKey, '']]
+Resources:
+  VPCFlowLogsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: Rights to Publish VPC Flow Logs to CloudWatch Logs
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service:
+                - vpc-flow-logs.amazonaws.com
+      Path: /
+      Policies:
+        - PolicyName: CloudWatchLogGroup
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:DescribeLogGroups
+                  - logs:DescribeLogStreams
+                Resource: !GetAtt VPCFlowLogsLogGroup.Arn
+  VPCFlowLogsLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: !Ref VPCFlowLogsLogGroupRetention
+      KmsKeyId: !If
+        - VPCFlowLogsCloudWatchKMSKeyCondition
+        - !Ref VPCFlowLogsCloudWatchKMSKey
+        - !Ref AWS::NoValue
+  VPCFlowLogstoCloudWatch:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      LogDestinationType: cloud-watch-logs
+      LogGroupName: !Ref VPCFlowLogsLogGroup
+      DeliverLogsPermissionArn: !GetAtt VPCFlowLogsRole.Arn
+      LogFormat: !Ref VPCFlowLogsLogFormat
+      MaxAggregationInterval: !Ref VPCFlowLogsMaxAggregationInterval
+      ResourceId: !Ref VPCID
+      ResourceType: VPC
+      TrafficType: !Ref VPCFlowLogsTrafficType
+      Tags:
+        - Key: Name
+          Value: VPC Flow Logs CloudWatch
+Outputs:
+  VPCFlowLogsLogGroup:
+    Description: CloudWatch Log Group where VPC Flow Log data will be published
+    Value: !Ref VPCFlowLogsLogGroup

--- a/aws/solutions/VPCFlowLogs/templates/VPCFlowLogsS3.cfn.yaml
+++ b/aws/solutions/VPCFlowLogs/templates/VPCFlowLogsS3.cfn.yaml
@@ -1,0 +1,191 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  This template enables VPC Flow Logs to S3. An option is provided to create an S3 bucket with encryption to host the flow logs.
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Network Configuration
+        Parameters:
+          - VPCID
+      - Label:
+          default: VPC Flow Logs Configuration
+        Parameters:
+          - VPCFlowLogsLogFormat
+          - VPCFlowLogsMaxAggregationInterval
+          - VPCFlowLogsTrafficType
+          - VPCFlowLogsBucketName
+          - VPCFlowLogsBucketKMSKey
+          - VPCFlowLogsBucketKeyEnabled
+          - S3AccessLogsBucketName
+    ParameterLabels:
+      S3AccessLogsBucketName:
+        default: S3 Access Logs Bucket Name
+      VPCFlowLogsBucketKeyEnabled:
+        default: VPC Flow Logs Bucket Key Enabled
+      VPCFlowLogsBucketKMSKey:
+        default: VPC Flow Logs Bucket KMS Key
+      VPCFlowLogsBucketName:
+        default: VPC Flow Logs Bucket Name
+      VPCFlowLogsLogFormat:
+        default: VPC Flow Logs - Log Format
+      VPCFlowLogsMaxAggregationInterval:
+        default: VPC Flow Logs - Max Aggregation Interval
+      VPCFlowLogsTrafficType:
+        default: VPC Flow Logs - Traffic Type
+      VPCID:
+        default: VPC ID
+Parameters:
+  S3AccessLogsBucketName:
+    AllowedPattern: '^$|^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
+    ConstraintDescription:
+      S3 Access Logs bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Default: ''
+    Description:
+      (Optional) S3 Access Logs bucket name for where Amazon S3 should store server access log files. S3 Access Logs bucket name can include numbers,
+      lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Type: String
+  VPCFlowLogsBucketKeyEnabled:
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+    Description:
+      Set to true to have Amazon S3 use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS). If false, S3 Bucket Key is not enabled.
+      Note, will only be set if KMS Key parameter, "VPCFlowLogsBucketKMSKey", was provided.
+    Type: String
+  VPCFlowLogsBucketKMSKey:
+    AllowedPattern: '^$|^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$|^arn:(aws[a-zA-Z-]*)?:kms:[a-z0-9-]+:\d{12}:key\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'
+    ConstraintDescription:
+      'Key ID example: 1234abcd-12ab-34cd-56ef-1234567890ab  Key ARN
+      example:  arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab'
+    Default: ''
+    Description:
+      (Optional) KMS Key ID or ARN to use for the default encryption. If empty, server-side encryption with Amazon S3-managed encryption keys (SSE-S3)
+      will be used. Note, will only be set if S3 Bucket parameter, "VPCFlowLogsBucketName", was not provided, thus a new S3 bucket is being created.
+    Type: String
+  VPCFlowLogsBucketName:
+    AllowedPattern: '^$|^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
+    ConstraintDescription:
+      S3 bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Default: ''
+    Description:
+      (Optional) S3 bucket name where VPC Flow Log data can be published. S3 bucket name can include numbers, lowercase letters, uppercase letters,
+      and hyphens (-). It cannot start or end with a hyphen (-). If empty, a new S3 bucket will be created for VPC Flow Log data to be published.
+    Type: String
+  VPCFlowLogsLogFormat:
+    AllowedPattern: '^(\$\{[a-z-]+\})$|^((\$\{[a-z-]+\} )*\$\{[a-z-]+\})$'
+    Default:
+      '${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action}
+      ${log-status}'
+    Description:
+      The fields to include in the flow log record, in the order in which they should appear. Specify the fields using the ${field-id} format,
+      separated by spaces. Using the Default Format as the default value.
+    Type: String
+  VPCFlowLogsMaxAggregationInterval:
+    AllowedValues:
+      - 60
+      - 600
+    Default: 600
+    Description:
+      The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. You can specify 60 seconds (1
+      minute) or 600 seconds (10 minutes).
+    Type: String
+  VPCFlowLogsTrafficType:
+    AllowedValues:
+      - ACCEPT
+      - ALL
+      - REJECT
+    Default: REJECT
+    Description: The type of traffic to log. You can log traffic that the resource accepts or rejects, or all traffic.
+    Type: String
+  VPCID:
+    Description: ID of the VPC (e.g., vpc-0343606e)
+    Type: AWS::EC2::VPC::Id
+Conditions:
+  S3AccessLogsCondition: !Not [!Equals [!Ref S3AccessLogsBucketName, '']]
+  VPCFlowLogsNewBucketCondition: !Not [!Equals [!Ref VPCFlowLogsBucketName, '']]
+  VPCFlowLogsBucketKMSKeyCondition: !Not [!Equals [!Ref VPCFlowLogsBucketKMSKey, '']]
+Resources:
+  VPCFlowLogstoS3:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      LogDestinationType: s3
+      LogDestination: !If
+        - VPCFlowLogsNewBucketCondition
+        - !Sub arn:aws:s3:::${VPCFlowLogsBucketName}
+        - !GetAtt VPCFlowLogsBucket.Arn
+      LogFormat: !Ref VPCFlowLogsLogFormat
+      MaxAggregationInterval: !Ref VPCFlowLogsMaxAggregationInterval
+      ResourceId: !Ref VPCID
+      ResourceType: VPC
+      TrafficType: !Ref VPCFlowLogsTrafficType
+      Tags:
+        - Key: Name
+          Value: VPC Flow Logs S3
+  VPCFlowLogsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub aws-vpcflowlogs-${AWS::AccountId}-${AWS::Region}
+      AccessControl: Private
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        BlockPublicPolicy: True
+        IgnorePublicAcls: True
+        RestrictPublicBuckets: True
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: !If
+                - VPCFlowLogsBucketKMSKeyCondition
+                - 'aws:kms'
+                - 'AES256'
+              KMSMasterKeyID: !If
+                - VPCFlowLogsBucketKMSKeyCondition
+                - !Ref VPCFlowLogsBucketKMSKey
+                - !Ref AWS::NoValue
+            BucketKeyEnabled: !If
+              - VPCFlowLogsBucketKMSKeyCondition
+              - !Ref VPCFlowLogsBucketKeyEnabled
+              - !Ref AWS::NoValue
+      LoggingConfiguration: !If
+        - S3AccessLogsCondition
+        - DestinationBucketName: !Ref S3AccessLogsBucketName
+        - !Ref AWS::NoValue
+      VersioningConfiguration:
+        Status: Enabled
+  VPCFlowLogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref VPCFlowLogsBucket
+      PolicyDocument:
+        Statement:
+          - Sid: AWSLogDeliveryWrite
+            Effect: Allow
+            Action: s3:PutObject
+            Resource: !Sub arn:${AWS::Partition}:s3:::${VPCFlowLogsBucket}/*
+            Principal:
+              Service: delivery.logs.amazonaws.com
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+          - Sid: AWSLogDeliveryAclCheck
+            Effect: Allow
+            Action: s3:GetBucketAcl
+            Resource: !Sub arn:${AWS::Partition}:s3:::${VPCFlowLogsBucket}
+            Principal:
+              Service: delivery.logs.amazonaws.com
+          - Sid: DenyNonSSLRequests
+            Effect: Deny
+            Action: s3:*
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::${VPCFlowLogsBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${VPCFlowLogsBucket}/*
+            Principal: '*'
+            Condition:
+              Bool:
+                aws:SecureTransport: false
+Outputs:
+  VPCFlowLogsBucket:
+    Description: S3 bucket name where VPC Flow Log data will be published
+    Value: !If [VPCFlowLogsNewBucketCondition, !Ref VPCFlowLogsBucket, !Ref VPCFlowLogsBucketName]


### PR DESCRIPTION
*Description of changes:*

This solution lets you enable Flow Logs for a VPC, and publish the flow log data to either CloudWatch Logs, S3, or both.

This solution can be implemented as individual templates accordingly, or leveraging the nested stacks `main` templates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
