### PR TITLE
adconnector - Solution creates an AD Connector to connect to an on-premises directory.

### DIFF
--- a/aws/solutions/ADConnector/README.md
+++ b/aws/solutions/ADConnector/README.md
@@ -1,0 +1,36 @@
+# AD Connector
+
+## Description
+
+This solution creates an AD Connector to connect to an on-premises directory.
+
+- (Optional) Create AWS resources (IAM role & instance profile) to support seamlessly join Windows EC2 instances to your AD Connector directory.
+- (Optional) Create AWS resources (IAM role, instance profile, and secret) to support seamlessly join Linux EC2 instances to your AD Connector
+  directory.
+- (Optional) Creates a Domain Members Security Group with **EXAMPLE** rules allowing all Private IP communications inbound.
+
+## Notes
+
+- AD Connector is not an AWS CloudFormation supported resource, therefore using an AWS CloudFormation custom resource.
+- CloudWatch Logs Log Group uses Amazon managed server-side encryption. Optionally, a KMS CMK can be used.
+- Secrets Manager Secrets using Amazon managed server-side encryption. Optionally, a KMS CMK can be used.
+- **NOTE** Security Group rules are configured to allow all inbound communications from [RFC1918](https://tools.ietf.org/html/rfc1918#section-3)
+  Private Address Space, which includes: `10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16`, this is used as an **EXAMPLE**, however, all security group
+  rules can be locked down based on the requirements.
+
+## Resources
+
+- [Active Directory Connector](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/directory_ad_connector.html)
+- [AD Connector Prerequisites](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/prereq_connector.html)
+- [Join an EC2 instance to your AD Connector directory](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ad_connector_join_instance.html)
+
+## Attributions
+
+Using the [aws-cloudformation/custom-resource-heper](https://github.com/aws-cloudformation/custom-resource-helper) to handle the AWS CloudFormation
+Custom Resource responses for the given resources.
+
+## Instructions
+
+1. Run [src/package.sh](src/package.sh) to package the code and dependencies.
+2. Upload the [src/adconnector_custom_resource.zip](src/adconnector_custom_resource.zip) to an S3 bucket, note the bucket name.
+3. Launch the AWS CloudFormation stack using the [ADCONNECTOR.cfn.yaml](templates/ADCONNECTOR.cfn.yaml) template file as the source.

--- a/aws/solutions/ADConnector/src/adconnector_custom_resource.py
+++ b/aws/solutions/ADConnector/src/adconnector_custom_resource.py
@@ -1,0 +1,134 @@
+"""Create and configure an ADConnector Directory.
+
+Copyright 2021 Amazon Web Services, Inc. or its affiliates. All Rights Reserved.
+This AWS Content is provided subject to the terms of the AWS Customer Agreement available at
+http://aws.amazon.com/agreement or other written agreement between Customer and either
+Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
+"""
+import json
+import logging
+import os
+
+import boto3
+from crhelper import CfnResource
+
+# Setup Default Logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.setLevel(os.environ.get("LOG_LEVEL", logging.ERROR))
+
+# Initialize the helper
+helper = CfnResource(json_logging=False, log_level="DEBUG", boto_level="CRITICAL")
+
+try:
+    ds_client = boto3.client("ds")
+    secretsmanager_client = boto3.client("secretsmanager")
+except Exception as error:
+    helper.init_failure(error)
+
+
+def get_adconnector_parameters(params: dict) -> dict:
+    """Creates a parameters dictionary for the ds:connect_directory API call to create AD Connector.
+
+    Args:
+        params: event resource properties
+
+    Returns:
+        ADConnector Parameters
+    """
+    # Get AD Domain Join Credentials from Secrets Manager
+    response = secretsmanager_client.get_secret_value(SecretId=params["DOMAIN_JOIN_SECRET_ID"])
+    secret = json.loads(response["SecretString"])
+    # Create DNS Servers List
+
+    return {
+        "Name": params["DOMAIN_DNS_NAME"],
+        "ShortName": params["DOMAIN_NETBIOS_NAME"],
+        "Password": secret.get("password"),
+        "Description": params["ADCONNECTOR_DESCRIPTION"],
+        "Size": params["ADCONNECTOR_SIZE"],
+        "ConnectSettings": {
+            "VpcId": params["ADCONNECTOR_VPCID"],
+            "SubnetIds": [params["ADCONNECTOR_SUBNET_ID1"], params["ADCONNECTOR_SUBNET_ID2"]],
+            "CustomerDnsIps": params["DOMAIN_DNS_SERVERS"].replace(", ", ",").split(","),
+            "CustomerUserName": secret.get("username"),
+        },
+    }
+
+
+@helper.create
+def create(event, context) -> str:
+    """Create Event from AWS CloudFormation.
+
+    Args:
+        event: event data
+        context: runtime information
+
+    Raises:
+        Exception: Captures all exceptions.
+
+    Returns:
+        ADConnectorDirectoryResourceID
+    """
+    try:
+        logger.info("Create Event")
+        logger.info(f"REQUEST RECEIVED: {json.dumps(event, default=str)}")
+        adconnector_params = get_adconnector_parameters(event["ResourceProperties"])
+        response = ds_client.connect_directory(**adconnector_params)
+        logger.info(f"connect_directory_response = {json.dumps(response, default=str)}")
+        helper.PhysicalResourceId = response["DirectoryId"]
+        return helper.PhysicalResourceId
+    except Exception as error:
+        raise error
+
+
+@helper.update
+def update(event, context):
+    """Update Event from AWS CloudFormation.
+
+    Args:
+        event: event data
+        context: runtime information
+
+    Raises:
+        Exception: Captures all exceptions.
+    """
+    try:
+        logger.info("Update Event")
+        logger.info(f"REQUEST RECEIVED: {json.dumps(event, default=str)}")
+    except Exception as error:
+        raise error
+
+
+@helper.delete
+def delete(event, context):
+    """Delete Event from AWS CloudFormation. Deletes the ADConnector Directory.
+
+    Args:
+        event: event data
+        context: runtime information
+
+    Raises:
+        Exception: Captures all exceptions.
+    """
+    try:
+        logger.info("Delete Event")
+        logger.info(f"REQUEST RECEIVED: {json.dumps(event, default=str)}")
+        helper.PhysicalResourceId = event.get("PhysicalResourceId")
+        directory_id = helper.PhysicalResourceId
+        logger.info(f"directory_id = {directory_id}")
+        response = ds_client.delete_directory(DirectoryId=directory_id)
+        logger.info(f"delete_directory_response = {json.dumps(response, default=str)}")
+    except Exception as error:
+        raise error
+
+
+def lambda_handler(event, context):
+    """Lambda Handler.
+
+    Args:
+        event: event data
+        context: runtime information
+    """
+    logger.info("....Lambda Handler Started....")
+    helper(event, context)

--- a/aws/solutions/ADConnector/src/package.sh
+++ b/aws/solutions/ADConnector/src/package.sh
@@ -1,0 +1,35 @@
+#!/usr/local/bin/bash
+
+# Builds a lambda package from a single Python 3 module with pip dependencies.
+# This is a modified version of the AWS packaging instructions:
+# https://docs.aws.amazon.com/lambda/latest/dg/lambda-python-how-to-create-deployment-package.html#python-package-dependencies
+
+# Set name of python script, excluding .py extension
+SCRIPT_NAME="adconnector_custom_resource"
+SCRIPT_DIRECTORY=$(pwd)
+
+# Clean-Up
+rm -rf .package .DS_Store "$SCRIPT_NAME".zip
+
+create_package() {
+    # Create .package directory
+    mkdir -p .package
+    # Add dependencies to .package, per the requirements.txt
+    pip3 install --target .package --requirement requirements.txt
+    # Add the python script to .package
+    cp ./"${SCRIPT_NAME}".py .package
+}
+
+# Includes Python Script & Dependencies (if any)
+make_zip() {
+    cd .package || exit
+    zip -r ../"${SCRIPT_NAME}".zip ./*
+    echo -e "\n### SCRIPT DIRECTORY:      ${SCRIPT_DIRECTORY}"
+    echo -e "\n### LAMBDA ZIP FILE:       ${SCRIPT_NAME}.zip"
+    cd ..
+}
+
+create_package
+make_zip
+
+echo -e "### LAMBDA PACKAGE SIZE:   $(du -sh .package)"

--- a/aws/solutions/ADConnector/src/requirements.txt
+++ b/aws/solutions/ADConnector/src/requirements.txt
@@ -1,0 +1,2 @@
+# DEPENDENCIES
+crhelper

--- a/aws/solutions/ADConnector/templates/ADCONNECTOR.cfn.yaml
+++ b/aws/solutions/ADConnector/templates/ADCONNECTOR.cfn.yaml
@@ -1,0 +1,626 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description:
+  This templates creates an AD Connector to connect to an on-premises directory. Tasks accomplished, (1) create AD Connector (2) option to create
+  seamless domain join resources for Windows & Linux EC2 instances (3) option to create a domain members security group that allows all PrivateIP
+  communications inbound (4) option to create DHCPOptionSet pointing to Domain DNS servers
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label: Network Configuration
+        Parameters:
+          - VPCID
+          - PrivateSubnet1ID
+          - PrivateSubnet2ID
+          - CreateADConnectorDomainMembersSG
+          - CreateDHCPOptionSet
+      - Label:
+          default: Active Directory Configuration (Onprem)
+        Parameters:
+          - DomainDNSName
+          - DomainNetBiosName
+          - DomainJoinUser
+          - DomainJoinUserPassword
+          - DomainDNSServers
+          - SecretsManagerDomainCredentialsSecretsKMSKey
+      - Label:
+          default: AD Connector Configuration
+        Parameters:
+          - ADConnectorSize
+          - ADConnectorDescription
+          - CreateWindowsEC2DomainJoinResources
+          - CreateLinuxEC2DomainJoinResources
+          - SSMLogsBucketName
+      - Label:
+          default: Lambda Function Configuration (AD Connector Custom Resource)
+        Parameters:
+          - LambdaFunctionName
+          - LambdaS3BucketName
+          - LambdaZipFileName
+          - LambdaLogsLogGroupRetention
+          - LambdaLogsCloudWatchKMSKey
+          - LambdaLogLevel
+    ParameterLabels:
+      ADConnectorDescription:
+        default: AD Connector Description
+      ADConnectorSize:
+        default: AD Connector Size
+      CreateDHCPOptionSet:
+        default: Create DHCP Option Set
+      CreateADConnectorDomainMembersSG:
+        default: Create Domain Members Security Group
+      CreateLinuxEC2DomainJoinResources:
+        default: Create AWS resources to support seamless domain join Linux EC2 instances
+      CreateWindowsEC2DomainJoinResources:
+        default: Create AWS resources to support seamless domain join Windows EC2 instances
+      DomainDNSName:
+        default: Domain DNS Name
+      DomainDNSServers:
+        default: Domain DNS Servers
+      DomainNetBiosName:
+        default: Domain NetBIOS Name
+      DomainJoinUser:
+        default: Domain Join User
+      DomainJoinUserPassword:
+        default: Domain Join User Password
+      LambdaFunctionName:
+        default: Lambda Function Name
+      LambdaLogLevel:
+        default: Lambda Log Level
+      LambdaLogsLogGroupRetention:
+        default: CloudWatch log retention days for Lambda logs
+      LambdaLogsCloudWatchKMSKey:
+        default: CloudWatch Logs KMS Key for Lambda logs
+      LambdaS3BucketName:
+        default: Lambda S3 Bucket Name
+      LambdaZipFileName:
+        default: Lambda Zip File Name
+      PrivateSubnet1ID:
+        default: Private Subnet 1 ID
+      PrivateSubnet2ID:
+        default: Private Subnet 2 ID
+      SecretsManagerDomainCredentialsSecretsKMSKey:
+        default: Secrets Manager KMS Key for domain credentials secret
+      SSMLogsBucketName:
+        default: Systems Manager (SSM) Logs Bucket Name
+      VPCID:
+        default: VPC ID
+Parameters:
+  ADConnectorDescription:
+    AllowedPattern: '^[A-Za-z0-9][\w@#%*+=:?.\/! -]*$'
+    Default: On-premises AD
+    Description: Description for the directory
+    MaxLength: 128
+    Type: String
+  ADConnectorSize:
+    AllowedValues: [Small, Large]
+    Default: Small
+    Description: Size of the directory
+    Type: String
+  CreateDHCPOptionSet:
+    AllowedValues: ['Yes', 'No']
+    Default: 'No'
+    Description: Create DHCP Option Set
+    Type: String
+  CreateADConnectorDomainMembersSG:
+    AllowedValues: ['Yes', 'No']
+    Default: 'No'
+    Description: Create Domain Members Security Group. Note, using allow any type rules, restrict accordingly.
+    Type: String
+  CreateLinuxEC2DomainJoinResources:
+    AllowedValues: ['Yes', 'No']
+    Default: 'No'
+    Description: Create AWS resources (IAM role, instance profile, & secret) to support seamless domain join Linux EC2 instances
+    Type: String
+  CreateWindowsEC2DomainJoinResources:
+    AllowedValues: ['Yes', 'No']
+    Default: 'No'
+    Description: Create AWS resources (IAM role & instnace profile)to support seamless domain join Windows EC2 instances
+    Type: String
+  DomainDNSName:
+    AllowedPattern: '[a-zA-Z0-9-]+..+'
+    Description: Fully qualified name of the on-premises directory, such as corp.example.com
+    MaxLength: 25
+    MinLength: 3
+    Type: String
+  DomainDNSServers:
+    AllowedPattern:
+      '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(,|,
+      ))*(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
+    ConstraintDescription:
+      Must be in the form of IP address. Additional IP addresses can be provided, separated by a "comma". (e.g., 10.1.1.1,10.2.2.2) Additional IP
+      addresses can be provided, separated by a "comma".
+    Description: DNS or domain controller servers for the on-premises directory.
+    Type: String
+  DomainNetBiosName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Description: Short name of your existing directory, such as CORP
+    MaxLength: 15
+    MinLength: 1
+    Type: String
+  DomainJoinUser:
+    AllowedPattern: '[a-zA-Z0-9]*'
+    Description: Username of a user in the existing directory
+    MaxLength: 25
+    MinLength: 5
+    Type: String
+  DomainJoinUserPassword:
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    Description: Password for the existing user account
+    MaxLength: 32
+    MinLength: 8
+    NoEcho: true
+    Type: String
+  LambdaFunctionName:
+    AllowedPattern: '^[\w-]{0,64}$'
+    ConstraintDescription: Max 64 alphanumeric characters. Also special characters supported [_, -]
+    Default: CR-ADConnector
+    Description: Lambda Function Name for Custom Resource.
+    Type: String
+  LambdaLogLevel:
+    AllowedValues: ['INFO', 'DEBUG']
+    Default: INFO
+    Description: Lambda logging level
+    Type: String
+  LambdaLogsLogGroupRetention:
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+    Default: 14
+    Description: Specifies the number of days you want to retain Lambda log events in the CloudWatch Logs
+    Type: String
+  LambdaLogsCloudWatchKMSKey:
+    AllowedPattern: '^$|^arn:(aws[a-zA-Z-]*)?:kms:[a-z0-9-]+:\d{12}:key\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'
+    ConstraintDescription: 'Key ARN example:  arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab'
+    Default: ''
+    Description:
+      (Optional) KMS Key ARN to use for encrypting the Lambda logs data. If empty, encryption is enabled with CloudWatch Logs managing the server-side
+      encryption keys.
+    Type: String
+  LambdaS3BucketName:
+    AllowedPattern: '(?=^.{3,63}$)(?!.*[.-]{2})(?!.*[--]{2})(?!^(?:(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])(\.(?!$)|$)){4}$)(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)'
+    ConstraintDescription:
+      Lambda S3 bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Description:
+      Lambda S3 bucket name for the Lambda deployment package. Lambda bucket name can include numbers, lowercase letters, uppercase letters, and
+      hyphens (-). It cannot start or end with a hyphen (-).
+    Type: String
+  LambdaZipFileName:
+    Default: adconnector_custom_resource.zip
+    Description: Amazon S3 key of the deployment package.
+    MaxLength: 1024
+    MinLength: 1
+    Type: String
+  PrivateSubnet1ID:
+    Description: ID of the private subnet 1 in Availability Zone 1 (e.g., subnet-a0246dcd)
+    Type: AWS::EC2::Subnet::Id
+  PrivateSubnet2ID:
+    Description: ID of the private subnet 2 in Availability Zone 2 (e.g., subnet-a0246dcd)
+    Type: AWS::EC2::Subnet::Id
+  SecretsManagerDomainCredentialsSecretsKMSKey:
+    AllowedPattern: '^$|^arn:(aws[a-zA-Z-]*)?:kms:[a-z0-9-]+:\d{12}:key\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'
+    ConstraintDescription: 'Key ARN example:  arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab'
+    Default: ''
+    Description:
+      (Optional) KMS Key ARN to use for encrypting the SecretsManager domain credentials secret. If empty, encryption is enabled with SecretsManager
+      managing the server-side encryption keys.
+    Type: String
+  SSMLogsBucketName:
+    AllowedPattern: '^$|(?=^.{3,63}$)(?!.*[.-]{2})(?!.*[--]{2})(?!^(?:(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])(\.(?!$)|$)){4}$)(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)'
+    ConstraintDescription:
+      SSM Logs bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Default: ''
+    Description:
+      (Optional) SSM Logs bucket name for where Systems Manager logs should store log files. SSM Logs bucket name can include numbers, lowercase
+      letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Type: String
+  VPCID:
+    Description: ID of the VPC (e.g., vpc-0343606e)
+    Type: AWS::EC2::VPC::Id
+Conditions:
+  DHCPOptionSetCondition: !Equals [!Ref CreateDHCPOptionSet, 'Yes']
+  DomainMembersSGCondition: !Equals [!Ref CreateADConnectorDomainMembersSG, 'Yes']
+  LambdaLogsCloudWatchKMSKeyCondition: !Not [!Equals [!Ref LambdaLogsCloudWatchKMSKey, '']]
+  LinuxEC2DomainJoinResourcesCondition: !Equals [!Ref CreateLinuxEC2DomainJoinResources, 'Yes']
+  SecretsManagerDomainCredentialsSecretsKMSKeyCondition: !Not [!Equals [!Ref SecretsManagerDomainCredentialsSecretsKMSKey, '']]
+  SSMLogsBucketNameCondition: !Not [!Equals [!Ref SSMLogsBucketName, '']]
+  WindowsEC2DomainJoinResourcesCondition: !Equals [!Ref CreateWindowsEC2DomainJoinResources, 'Yes']
+Resources:
+  ADConnectorDomainMembersSG:
+    Condition: DomainMembersSGCondition
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W42
+            reason: Allow all inbound communications from Private IP CIDRs (for Lab purposes)
+          - id: W40
+            reason: Allow all outbound communications (for Lab purposes)
+          - id: W5
+            reason: Allow all outbound communications (for Lab purposes)
+          - id: W9
+            reason: Allow all inbound communications from Private IP CIDRs (for Lab purposes)
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub ${DomainNetBiosName} Domain Members SG via AD Connector
+      VpcId: !Ref VPCID
+      SecurityGroupIngress:
+        - IpProtocol: '-1'
+          Description: LAB - Allow All Private IP Communications
+          CidrIp: 10.0.0.0/8
+        - IpProtocol: '-1'
+          Description: LAB - Allow All Private IP Communications
+          CidrIp: 172.16.0.0/12
+        - IpProtocol: '-1'
+          Description: LAB - Allow All Private IP Communications
+          CidrIp: 192.168.0.0/16
+      SecurityGroupEgress:
+        - Description: Allow All Outbound Communications
+          IpProtocol: '-1'
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: !Sub ${DomainNetBiosName}-DomainMembersSG-ADConnector
+  ADConnectorLambdaFunction:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W58
+            reason: Permissions to write to CloudWatch Logs provided by the attached IAM role
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Ref LambdaFunctionName
+      Handler: adconnector_custom_resource.lambda_handler
+      Role: !GetAtt ADConnectorLambdaRole.Arn
+      Runtime: python3.8
+      MemorySize: 128
+      Timeout: 120
+      Environment:
+        Variables:
+          LOG_LEVEL: !Ref LambdaLogLevel
+      Code:
+        S3Bucket: !Ref LambdaS3BucketName
+        S3Key: !Ref LambdaZipFileName
+  ADConnectorLambdaLogsLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${LambdaFunctionName}
+      RetentionInDays: !Ref LambdaLogsLogGroupRetention
+      KmsKeyId: !If
+        - LambdaLogsCloudWatchKMSKeyCondition
+        - !Ref LambdaLogsCloudWatchKMSKey
+        - !Ref AWS::NoValue
+  ADConnectorLambdaRole:
+    Type: AWS::IAM::Role
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: Allow * in resource when required
+          - id: W28
+            reason: The role name is defined to identify automation resources
+    Properties:
+      RoleName: !Sub ${LambdaFunctionName}-LambdaRole
+      Description: Rights to Setup AD Connector
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+      Path: /
+      Tags:
+        - Key: StackName
+          Value: !Ref AWS::StackName
+      Policies:
+        - PolicyName: CloudWatchLogGroup
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CreateLogGroup
+                Effect: Allow
+                Action: logs:CreateLogGroup
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${ADConnectorLambdaLogsLogGroup}
+              - Sid: CreateLogStreamAndEvents
+                Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${ADConnectorLambdaLogsLogGroup}:log-stream:*
+        - PolicyName: ADConnector
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: Directory
+                Effect: Allow
+                Action:
+                  - ds:ConnectDirectory
+                  - ds:DeleteDirectory
+                Resource: '*'
+              - Sid: CreateAdConnectorEc2Resources
+                Effect: Allow
+                Action:
+                  - ec2:DescribeSubnets
+                  - ec2:DescribeVpcs
+                  - ec2:CreateSecurityGroup
+                  - ec2:CreateNetworkInterface
+                  - ec2:DescribeNetworkInterfaces
+                  - ec2:AuthorizeSecurityGroupIngress
+                  - ec2:AuthorizeSecurityGroupEgress
+                  - ec2:CreateTags
+                Resource: '*'
+                Condition:
+                  Bool:
+                    aws:ViaAWSService: true
+              - Sid: DeleteAdConnectorEc2Resources
+                Effect: Allow
+                Action:
+                  - ec2:DeleteSecurityGroup
+                  - ec2:DescribeNetworkInterfaces
+                  - ec2:DeleteNetworkInterface
+                  - ec2:RevokeSecurityGroupIngress
+                  - ec2:RevokeSecurityGroupEgress
+                  - ec2:DeleteTags
+                Resource: '*'
+                Condition:
+                  Bool:
+                    aws:ViaAWSService: true
+        - PolicyName: ADConnectorServiceAccountSecret
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: GetSecret
+                Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: !Ref ADConnectorServiceAccountSecret
+        - !If
+          - SecretsManagerDomainCredentialsSecretsKMSKeyCondition
+          - PolicyName: KMSKeyForSecret
+            PolicyDocument:
+              Version: 2012-10-17
+              Statement:
+                - Effect: Allow
+                  Action: kms:Decrypt
+                  Resource: !Ref SecretsManagerDomainCredentialsSecretsKMSKey
+          - !Ref AWS::NoValue
+  ADConnectorLinuxEC2DomainJoinInstanceProfile:
+    Condition: LinuxEC2DomainJoinResourcesCondition
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: !Ref ADConnectorLinuxEC2DomainJoinRole
+      Path: /
+      Roles:
+        - !Ref ADConnectorLinuxEC2DomainJoinRole
+  ADConnectorLinuxEC2DomainJoinRole:
+    Condition: LinuxEC2DomainJoinResourcesCondition
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: The role name is defined to identify automation resources
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${DomainNetBiosName}-LinuxEC2DomainJoinRole-ADConnector
+      Description: !Sub IAM Role to Seamlessly Join Linux EC2 Instances to ${DomainNetBiosName} Domain via AD Connector
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+      Path: /
+      Tags:
+        - Key: StackName
+          Value: !Ref AWS::StackName
+      Policies:
+        - PolicyName: SSMAgent
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource:
+                  - !Sub arn:aws:s3:::aws-ssm-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-windows-downloads-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::amazon-ssm-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::amazon-ssm-packages-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::${AWS::Region}-birdwatcher-prod/*
+                  - !Sub arn:aws:s3:::patch-baseline-snapshot-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-ssm-distributor-file-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-ssm-document-attachments-${AWS::Region}/*
+        - !If
+          - SSMLogsBucketNameCondition
+          - PolicyName: SsmLogs
+            PolicyDocument:
+              Version: 2012-10-17
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - s3:GetObject
+                    - s3:PutObject
+                    - s3:PutObjectAcl
+                    - s3:GetEncryptionConfiguration
+                  Resource:
+                    - !Sub arn:aws:s3:::${SSMLogsBucketName}
+                    - !Sub arn:aws:s3:::${SSMLogsBucketName}/*
+          - !Ref AWS::NoValue
+        - PolicyName: ADConnectorLinuxEC2SeamlessDomainJoinSecret
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                  - secretsmanager:DescribeSecret
+                Resource: !Ref ADConnectorLinuxEC2SeamlessDomainJoinSecret
+        - !If
+          - SecretsManagerDomainCredentialsSecretsKMSKeyCondition
+          - PolicyName: KMSKeyForSecret
+            PolicyDocument:
+              Version: 2012-10-17
+              Statement:
+                - Effect: Allow
+                  Action: kms:Decrypt
+                  Resource: !Ref SecretsManagerDomainCredentialsSecretsKMSKey
+          - !Ref AWS::NoValue
+  ADConnectorLinuxEC2SeamlessDomainJoinSecret:
+    Condition: LinuxEC2DomainJoinResourcesCondition
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub aws/directory-services/${ADConnectorResource}/seamless-domain-join
+      Description: !Sub AD Credentials for Seamless Domain Join Windows/Linux EC2 instances to ${DomainNetBiosName} Domain via AD Connector
+      SecretString: !Sub '{ "awsSeamlessDomainUsername" : "${DomainJoinUser}", "awsSeamlessDomainPassword" : "${DomainJoinUserPassword}" }'
+      KmsKeyId: !If
+        - SecretsManagerDomainCredentialsSecretsKMSKeyCondition
+        - !Ref SecretsManagerDomainCredentialsSecretsKMSKey
+        - !Ref AWS::NoValue
+  ADConnectorResource:
+    Type: Custom::ADConnectorResource
+    Version: '1.0'
+    Properties:
+      ServiceToken: !GetAtt ADConnectorLambdaFunction.Arn
+      ADCONNECTOR_DESCRIPTION: !Ref ADConnectorDescription
+      ADCONNECTOR_SIZE: !Ref ADConnectorSize
+      ADCONNECTOR_SUBNET_ID1: !Ref PrivateSubnet1ID
+      ADCONNECTOR_SUBNET_ID2: !Ref PrivateSubnet2ID
+      ADCONNECTOR_VPCID: !Ref VPCID
+      DOMAIN_DNS_NAME: !Ref DomainDNSName
+      DOMAIN_DNS_SERVERS: !Ref DomainDNSServers
+      DOMAIN_NETBIOS_NAME: !Ref DomainNetBiosName
+      DOMAIN_JOIN_SECRET_ID: !Ref ADConnectorServiceAccountSecret
+  ADConnectorServiceAccountSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub ADConnector-ServiceAccount-${DomainNetBiosName}-Domain
+      Description: !Sub ADConnector Service Account for ${DomainNetBiosName} Domain
+      SecretString: !Sub '{ "username" : "${DomainJoinUser}", "password" : "${DomainJoinUserPassword}" }'
+      KmsKeyId: !If
+        - SecretsManagerDomainCredentialsSecretsKMSKeyCondition
+        - !Ref SecretsManagerDomainCredentialsSecretsKMSKey
+        - !Ref AWS::NoValue
+  ADConnectorWindowsEC2DomainJoinInstanceProfile:
+    Condition: WindowsEC2DomainJoinResourcesCondition
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: !Ref ADConnectorWindowsEC2DomainJoinRole
+      Path: /
+      Roles:
+        - !Ref ADConnectorWindowsEC2DomainJoinRole
+  ADConnectorWindowsEC2DomainJoinRole:
+    Condition: WindowsEC2DomainJoinResourcesCondition
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: The role name is defined to identify automation resources
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${DomainNetBiosName}-ADConnector-WindowsEC2DomainJoinRole
+      Description: !Sub IAM Role to Seamlessly Join Windows EC2 Instances to ${DomainDNSName} Domain via AD Connector
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+      Path: /
+      Tags:
+        - Key: StackName
+          Value: !Ref AWS::StackName
+      Policies:
+        - PolicyName: SSMAgent
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource:
+                  - !Sub arn:aws:s3:::aws-ssm-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-windows-downloads-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::amazon-ssm-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::amazon-ssm-packages-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::${AWS::Region}-birdwatcher-prod/*
+                  - !Sub arn:aws:s3:::patch-baseline-snapshot-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-ssm-distributor-file-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-ssm-document-attachments-${AWS::Region}/*
+        - !If
+          - SSMLogsBucketNameCondition
+          - PolicyName: SsmLogs
+            PolicyDocument:
+              Version: 2012-10-17
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - s3:GetObject
+                    - s3:PutObject
+                    - s3:PutObjectAcl
+                    - s3:GetEncryptionConfiguration
+                  Resource:
+                    - !Sub arn:aws:s3:::${SSMLogsBucketName}
+                    - !Sub arn:aws:s3:::${SSMLogsBucketName}/*
+          - !Ref AWS::NoValue
+  DHCPOptions:
+    Condition: DHCPOptionSetCondition
+    Type: AWS::EC2::DHCPOptions
+    Properties:
+      DomainName: !Ref DomainDNSName
+      DomainNameServers:
+        - !Ref DomainDNSServers
+      Tags:
+        - Key: Name
+          Value: !Ref DomainDNSName
+  DHCPOptionsVPCAssociation:
+    Condition: DHCPOptionSetCondition
+    Type: AWS::EC2::VPCDHCPOptionsAssociation
+    Properties:
+      VpcId: !Ref VPCID
+      DhcpOptionsId: !Ref DHCPOptions
+Outputs:
+  ADConnectorDirectoryId:
+    Description: AD Connector Directory ID
+    Value: !Ref ADConnectorResource
+    Export:
+      Name: !Sub ${AWS::StackName}-ADConnectorDirectoryId
+  ADConnectorDirectoryName:
+    Description: AD Connector Directory Name
+    Value: !Ref DomainDNSName
+    Export:
+      Name: !Sub ${AWS::StackName}-ADConnectorDirectoryName
+  ADConnectorADConnectorDomainMembersSG:
+    Condition: DomainMembersSGCondition
+    Description: ADConnector Domain Members Security Group
+    Value: !Ref ADConnectorDomainMembersSG
+    Export:
+      Name: !Sub ${AWS::StackName}-${DomainNetBiosName}-ADConnectorDomainMembersSG
+  ADConnectorWindowsEC2SeamlessDomainJoinInstanceProfile:
+    Condition: WindowsEC2DomainJoinResourcesCondition
+    Description: IAM Instance Profile with SSM Document Rights to Join Windows Computers via AD Connector
+    Value: !Ref ADConnectorWindowsEC2DomainJoinInstanceProfile
+    Export:
+      Name: !Sub ${AWS::StackName}-${DomainNetBiosName}-ADConnectorWindowsEC2DomainJoinProfile
+  ADConnectorWindowsEC2SeamlessDomainJoinRole:
+    Condition: WindowsEC2DomainJoinResourcesCondition
+    Description: IAM Instance Profile with SSM Document Rights to Join Windows Computers via AD Connector
+    Value: !Ref ADConnectorWindowsEC2DomainJoinRole
+    Export:
+      Name: !Sub ${AWS::StackName}-${DomainNetBiosName}-ADConnectorWindowsEC2DomainJoinRole
+  ADConnectorLinuxEC2SeamlessDomainJoinInstanceProfile:
+    Condition: LinuxEC2DomainJoinResourcesCondition
+    Description: IAM Instance Profile with SSM Document Rights to Join Linux Computers via AD Connector
+    Value: !Ref ADConnectorLinuxEC2DomainJoinInstanceProfile
+    Export:
+      Name: !Sub ${AWS::StackName}-${DomainNetBiosName}-ADConnectorLinuxEC2DomainJoinProfile
+  ADConnectorLinuxEC2SeamlessDomainJoinRole:
+    Condition: LinuxEC2DomainJoinResourcesCondition
+    Description: IAM Instance Profile with SSM Document Rights to Join Linux Computers via AD Connector
+    Value: !Ref ADConnectorLinuxEC2DomainJoinRole
+    Export:
+      Name: !Sub ${AWS::StackName}-${DomainNetBiosName}-ADConnectorLinuxEC2DomainJoinRole


### PR DESCRIPTION
*Description of changes:*
This solution creates an AD Connector to connect to an on-premises directory.

- (Optional) Create AWS resources (IAM role & instance profile) to support seamlessly join Windows EC2 instances to your AD Connector directory.
- (Optional) Create AWS resources (IAM role, instance profile, and secret) to support seamlessly join Linux EC2 instances to your AD Connector directory.
- (Optional) Creates a Domain Members Security Group with **EXAMPLE** rules allowing all Private IP communications inbound.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
