### PR TITLE
directoryadclients - Solution creates Linux and Windows EC2 instances and joins them to Active Directory (AD) via AD Connector or AWS Managed AD directory via different SSM Association methods.

### DIFF
--- a/aws/solutions/DirectoryADClients/README.md
+++ b/aws/solutions/DirectoryADClients/README.md
@@ -1,0 +1,37 @@
+# DIRECTORY-AD-CLIENTS
+
+## Description
+
+This solution creates Linux and Windows EC2 instances and joins them to Active Directory (AD) via AD Connector or AWS Managed AD directory via
+different SSM Association methods.
+
+- `AWS-JoinDirectoryServiceDomain` SSM document is used to join AD domain.
+- To join AD domain, EC2 instances must be able to resolve the AD domain, 2 options provided:
+  - By default, DHCPOptionsSet is relied on to be able to resolve the AD domain.
+  - If Domain DNS servers are provided, then they are set manually on the EC2 instances.
+- Different methods used to initiate the Domain Join, as examples:
+  - Windows EC2 instance using an inline SSM association
+  - Windows and Linux EC2 instance using an SSM association resource targeting EC2 instance IDs
+  - Windows EC2 instance using an SSM association resource targeting EC2 instance tags
+
+## Notes
+
+- For Linux Hosts, the
+  [ssm-agent domainjoin plugin](https://github.com/aws/amazon-ssm-agent/blob/mainline/agent/plugins/domainjoin/domainjoin_unix_script.go), ignores
+  hostname, and creates a random hostname with prefix "EC2AMAZ-"
+- If NetBIOS name already exists in Active Directory, the domain join will fail.
+  - Terminating an EC2 instance that was previous joined to Active Directory, does not delete the Computer Name. Remember to delete computer name in
+    AD.
+- Amazon EBS Volumes using Amazon managed server-side encryption or the CMK set as the default EBS encryption key. Optionally, a KMS CMK can be used.
+- Amazon EC2 instance inline SSM associations, provides limited properties compared to using an
+  [SSM Association resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-association.html).
+
+## Resources
+
+- [Join an EC2 instance to your AD Connector directory](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ad_connector_join_instance.html)
+- [Join an EC2 instance to your AWS Managed Microsoft AD directory](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_join_instance.html)
+- [amazon-ssm-agent/agent/plugins/domainjoin](https://github.com/aws/amazon-ssm-agent/tree/mainline/agent/plugins/domainjoin)
+
+## Instructions
+
+1. Launch the AWS CloudFormation stack using the [DIRECTORY-AD-CLIENTS.cfn.yaml](templates/DIRECTORY-AD-CLIENTS.cfn.yaml) template file as the source.

--- a/aws/solutions/DirectoryADClients/templates/DIRECTORY-AD-CLIENTS.yaml
+++ b/aws/solutions/DirectoryADClients/templates/DIRECTORY-AD-CLIENTS.yaml
@@ -1,0 +1,430 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description:
+  This template creates (1) Linux and (3) Windows EC2 instances and joins them to Active Directory using the 'AWS-JoinDirectoryServiceDomain' SSM
+  document via AD Connector or AWS Managed AD directory. By default, it relies on the DNS servers being used by the EC2 instances knowing how to
+  resolve the AD domain (i.e., Route 53 Resolvers, DHCP OptionsSet), with an option to set the DNS servers manually on the EC2 instances, as
+  necessary. Several methods used to initiate the domain join (1) Windows EC2 instance with inline SSM association (2) Windows and Linux EC2 instance
+  with SSM association targeting EC2 instance IDs (3) Windows EC2 instance with SSM association targeting EC2 instance tags
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Network Configuration
+        Parameters:
+          - PrivateSubnet1ID
+          - PrivateSubnet2ID
+      - Label:
+          default: EC2 Instance Configuration
+        Parameters:
+          - DomainMembersInstanceType
+          - DomainMember1NetBIOSName
+          - DomainMember2NetBIOSName
+          - DomainMember3NetBIOSName
+          - DomainMember4NetBIOSName
+          - KeyPairName
+          - DomainMembersLinuxInstanceProfile
+          - DomainMembersWindowsInstanceProfile
+          - DomainMembersSGID
+          - EBSKMSKey
+          - AMAZONLINUX2
+          - WINFULLBASE
+          - SSMLogsBucketName
+      - Label:
+          default: Directory Services Configuration
+        Parameters:
+          - DirectoryID
+          - DirectoryName
+          - DomainDNSServer1
+          - DomainDNSServer2
+          - DomainDNSServer3
+          - DomainDNSServer4
+    ParameterLabels:
+      AMAZONLINUX2:
+        default: SSM Parameter Value for Lastest Amazon Linux 2 AMI ID
+      DirectoryID:
+        default: ID of the Directory (e.g., d-906764663a)
+      DirectoryName:
+        default: Directory Name
+      DomainDNSServer1:
+        default: Domain DNS Server 1
+      DomainDNSServer2:
+        default: Domain DNS Server 2
+      DomainDNSServer3:
+        default: Domain DNS Server 3
+      DomainDNSServer4:
+        default: Domain DNS Server 4
+      DomainMember1NetBIOSName:
+        default: Domain Member 1 NetBIOS Name
+      DomainMember2NetBIOSName:
+        default: Domain Member 2 NetBIOS Name
+      DomainMember3NetBIOSName:
+        default: Domain Member 3 NetBIOS Name
+      DomainMember4NetBIOSName:
+        default: Domain Member 4 NetBIOS Name
+      DomainMembersInstanceType:
+        default: Domain Members Instance Type
+      DomainMembersSGID:
+        default: Domain Members Security Group
+      DomainMembersLinuxInstanceProfile:
+        default: Domain Member Linux InstanceProfile
+      DomainMembersWindowsInstanceProfile:
+        default: Domain Member Windows InstanceProfile
+      EBSKMSKey:
+        default: Amazon EBS Volume KMS Key
+      KeyPairName:
+        default: Key Pair Name
+      PrivateSubnet1ID:
+        default: Private Subnet 1 ID
+      PrivateSubnet2ID:
+        default: Private Subnet 2 ID
+      SSMLogsBucketName:
+        default: SSM Logs Bucket Name
+      WINFULLBASE:
+        default: SSM Parameter Value for Lastest Windows AMI ID
+Parameters:
+  AMAZONLINUX2:
+    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+  DirectoryID:
+    AllowedPattern: '^d-[0-9a-f]{10}$'
+    Description: Directory ID
+    Type: String
+  DirectoryName:
+    AllowedPattern: '[a-zA-Z0-9-]+..+'
+    Description: Fully qualified name of the on-premises directory, such as corp.example.com
+    MaxLength: 25
+    MinLength: 3
+    Type: String
+  DomainDNSServer1:
+    AllowedPattern: '^$|^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
+    Description:
+      (Optional) Domain DNS Server 1. If DNS servers are not set, then you need to ensure the DNS servers the EC2 instances are using can resolve the
+      AD domain.
+    Type: String
+  DomainDNSServer2:
+    AllowedPattern: '^$|^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
+    Description:
+      (Optional) Domain DNS Server 2. If DNS servers are not set, then you need to ensure the DNS servers the EC2 instances are using can resolve the
+      AD domain.
+    Type: String
+  DomainDNSServer3:
+    AllowedPattern: '^$|^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
+    Description:
+      (Optional) Domain DNS Server 3. If DNS servers are not set, then you need to ensure the DNS servers the EC2 instances are using can resolve the
+      AD domain.
+    Type: String
+  DomainDNSServer4:
+    AllowedPattern: '^$|^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
+    Description:
+      (Optional) Domain DNS Server 4. If DNS servers are not set, then you need to ensure the DNS servers the EC2 instances are using can resolve the
+      AD domain.
+    Type: String
+  DomainMember1NetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: SERVER1
+    Description: NetBIOS name of Domain Member 1 (using inline SSM association). Note, if computer name existed in AD before, delete from AD first.
+    MaxLength: 15
+    MinLength: 1
+    Type: String
+  DomainMember2NetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: SERVER2
+    Description:
+      NetBIOS name of Domain Member 2 (using SSM association via instance id). Note, if computer name existed in AD before, delete from AD first.
+    MaxLength: 15
+    MinLength: 1
+    Type: String
+  DomainMember3NetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: SERVER3
+    Description: NetBIOS name of Domain Member 3 (using SSM association via tag). Note, if computer name existed in AD before, delete from AD first.
+    MaxLength: 15
+    MinLength: 1
+    Type: String
+  DomainMember4NetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: SERVER4
+    Description: NetBIOS name of Domain Member 4 (AmazonLinux2)
+    MaxLength: 15
+    MinLength: 1
+    Type: String
+  DomainMembersInstanceType:
+    AllowedValues: [t3.medium, t3.large]
+    Default: t3.medium
+    Description: Amazon EC2 instance type for the AD Server instances
+    Type: String
+  DomainMembersLinuxInstanceProfile:
+    AllowedPattern: '[\w+=,.@-]+'
+    Description: Existing IAM InstanceProfile with Linux EC2 seamless join domain rights
+    Type: String
+  DomainMembersWindowsInstanceProfile:
+    AllowedPattern: '[\w+=,.@-]+'
+    Description: Existing IAM InstanceProfile with Windows EC2 seamless join domain rights
+    Type: String
+  DomainMembersSGID:
+    Description: Security Group ID for Domain Members Security Group
+    Type: AWS::EC2::SecurityGroup::Id
+  EBSKMSKey:
+    AllowedPattern: '^$|(^alias/[a-zA-Z0-9/-]{1,256}$)|(^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$)|(^arn:(aws[a-z-]*)?:kms:.*:\d{12}:key/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$)|(^arn:(aws[a-z-]*)?:kms:.*:\d{12}:alias/[a-zA-Z0-9/-]{1,256}$)'
+    Description:
+      (Optional) KMS Alias, Key ID, Key ID ARN or Alias ARN to use for encrypting the EBS volumes. If empty, the default key for EBS encryption will
+      be used of `alias/aws/ebs` or the CMK set as the default EBS encryption key.
+    Type: String
+  KeyPairName:
+    Description: KeyPair for ONPREMISES INSTANCES
+    Type: AWS::EC2::KeyPair::KeyName
+  PrivateSubnet1ID:
+    Description: ID of the private subnet 1 in Availability Zone 1 (e.g., subnet-a0246dcd)
+    Type: AWS::EC2::Subnet::Id
+  PrivateSubnet2ID:
+    Description: ID of the private subnet 2 in Availability Zone 2 (e.g., subnet-a0246dcd)
+    Type: AWS::EC2::Subnet::Id
+  SSMLogsBucketName:
+    AllowedPattern: '^$|(?=^.{3,63}$)(?!.*[.-]{2})(?!.*[--]{2})(?!^(?:(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])(\.(?!$)|$)){4}$)(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)'
+    ConstraintDescription:
+      SSM Logs bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Description:
+      (Optional) SSM Logs bucket name for where Systems Manager logs should store log files. SSM Logs bucket name can include numbers, lowercase
+      letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Type: String
+  WINFULLBASE:
+    Default: /aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+Conditions:
+  DomainDNSServer1Condition: !Not [!Equals [!Ref DomainDNSServer1, '']]
+  DomainDNSServer2Condition: !Not [!Equals [!Ref DomainDNSServer2, '']]
+  DomainDNSServer3Condition: !Not [!Equals [!Ref DomainDNSServer3, '']]
+  DomainDNSServer4Condition: !Not [!Equals [!Ref DomainDNSServer4, '']]
+  DomainDNSServersCondition: !Or
+    - !Condition DomainDNSServer1Condition
+    - !Condition DomainDNSServer2Condition
+    - !Condition DomainDNSServer3Condition
+    - !Condition DomainDNSServer4Condition
+  EBSKMSKeyCondition: !Not [!Equals [!Ref EBSKMSKey, '']]
+  SSMLogsBucketCondition: !Not [!Equals [!Ref SSMLogsBucketName, '']]
+Resources:
+  DomainMember1WithInlineSsmAssociation:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref WINFULLBASE
+      IamInstanceProfile: !Ref DomainMembersWindowsInstanceProfile
+      SsmAssociations:
+        - DocumentName: AWS-JoinDirectoryServiceDomain
+          AssociationParameters:
+            - Key: directoryId
+              Value:
+                - !Ref DirectoryID
+            - Key: directoryName
+              Value:
+                - !Ref DirectoryName
+            - !If
+              - DomainDNSServersCondition
+              - Key: dnsIpAddresses
+                Value:
+                  - !If [DomainDNSServer1Condition, !Ref DomainDNSServer1, !Ref AWS::NoValue]
+                  - !If [DomainDNSServer2Condition, !Ref DomainDNSServer2, !Ref AWS::NoValue]
+                  - !If [DomainDNSServer3Condition, !Ref DomainDNSServer3, !Ref AWS::NoValue]
+                  - !If [DomainDNSServer4Condition, !Ref DomainDNSServer4, !Ref AWS::NoValue]
+              - !Ref AWS::NoValue
+      InstanceType: !Ref DomainMembersInstanceType
+      SubnetId: !Ref PrivateSubnet1ID
+      Tags:
+        - Key: Name
+          Value: !Ref DomainMember1NetBIOSName
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            Encrypted: true
+            VolumeType: gp3
+            DeleteOnTermination: true
+            VolumeSize: 100
+            KmsKeyId: !If
+              - EBSKMSKeyCondition
+              - !Ref EBSKMSKey
+              - !Ref AWS::NoValue
+      SecurityGroupIds:
+        - !Ref DomainMembersSGID
+      KeyName: !Ref KeyPairName
+      UserData:
+        Fn::Base64: !Sub |
+          <powershell>
+          $instanceId = "null"
+          while ($instanceId -NotLike "i-*") {
+          Start-Sleep -s 3
+          $instanceId = Invoke-RestMethod -uri http://169.254.169.254/latest/meta-data/instance-id
+          }
+          Rename-Computer -NewName ${DomainMember1NetBIOSName} -Force
+          # Set-TimeZone -Name "US Eastern Standard Time"
+
+          Install-WindowsFeature -IncludeAllSubFeature RSAT
+          Restart-Computer -Force
+          </powershell>
+  DomainMember2WithSsmAssociationInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref WINFULLBASE
+      IamInstanceProfile: !Ref DomainMembersWindowsInstanceProfile
+      InstanceType: !Ref DomainMembersInstanceType
+      SubnetId: !Ref PrivateSubnet2ID
+      Tags:
+        - Key: Name
+          Value: !Ref DomainMember2NetBIOSName
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            Encrypted: true
+            VolumeType: gp3
+            DeleteOnTermination: true
+            VolumeSize: 100
+            KmsKeyId: !If
+              - EBSKMSKeyCondition
+              - !Ref EBSKMSKey
+              - !Ref AWS::NoValue
+      SecurityGroupIds:
+        - !Ref DomainMembersSGID
+      KeyName: !Ref KeyPairName
+      UserData:
+        Fn::Base64: !Sub |
+          <powershell>
+          $instanceId = "null"
+          while ($instanceId -NotLike "i-*") {
+          Start-Sleep -s 3
+          $instanceId = Invoke-RestMethod -uri http://169.254.169.254/latest/meta-data/instance-id
+          }
+          Rename-Computer -NewName ${DomainMember2NetBIOSName} -Force
+          # Set-TimeZone -Name "US Eastern Standard Time"
+
+          Install-WindowsFeature -IncludeAllSubFeature RSAT
+          Restart-Computer -Force
+          </powershell>
+  DomainMember3WithSsmAssociationTag:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref WINFULLBASE
+      IamInstanceProfile: !Ref DomainMembersWindowsInstanceProfile
+      InstanceType: !Ref DomainMembersInstanceType
+      SubnetId: !Ref PrivateSubnet1ID
+      Tags:
+        - Key: Name
+          Value: !Ref DomainMember3NetBIOSName
+        - Key: DomainJoin
+          Value: !Ref DirectoryName
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            Encrypted: true
+            VolumeType: gp3
+            DeleteOnTermination: true
+            VolumeSize: 100
+            KmsKeyId: !If
+              - EBSKMSKeyCondition
+              - !Ref EBSKMSKey
+              - !Ref AWS::NoValue
+      SecurityGroupIds:
+        - !Ref DomainMembersSGID
+      KeyName: !Ref KeyPairName
+      UserData:
+        Fn::Base64: !Sub |
+          <powershell>
+          $instanceId = "null"
+          while ($instanceId -NotLike "i-*") {
+          Start-Sleep -s 3
+          $instanceId = Invoke-RestMethod -uri http://169.254.169.254/latest/meta-data/instance-id
+          }
+          Rename-Computer -NewName ${DomainMember3NetBIOSName} -Force
+          # Set-TimeZone -Name "US Eastern Standard Time"
+
+          Install-WindowsFeature -IncludeAllSubFeature RSAT
+          Restart-Computer -Force
+          </powershell>
+  DomainMember4LinuxWithSsmAssociationInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref AMAZONLINUX2
+      IamInstanceProfile: !Ref DomainMembersLinuxInstanceProfile
+      InstanceType: !Ref DomainMembersInstanceType
+      SubnetId: !Ref PrivateSubnet2ID
+      Tags:
+        - Key: Name
+          Value: !Ref DomainMember4NetBIOSName
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            Encrypted: true
+            VolumeType: gp3
+            DeleteOnTermination: true
+            VolumeSize: 100
+            KmsKeyId: !If
+              - EBSKMSKeyCondition
+              - !Ref EBSKMSKey
+              - !Ref AWS::NoValue
+      SecurityGroupIds:
+        - !Ref DomainMembersSGID
+      KeyName: !Ref KeyPairName
+      UserData:
+        Fn::Base64: !Sub |
+          # Set HostName
+          LowerEc2Name=$(echo ${DomainMember4NetBIOSName} | tr '[:upper:]' '[:lower:]')
+          sudo hostnamectl set-hostname $LowerEc2Name
+          # Set TimeZone
+          # sudo sed -i 's|^ZONE=.*|ZONE="America/New_York"|' /etc/sysconfig/clock
+          # sudo ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
+          # Patch System Up
+          sudo yum update -y
+          # Reboot
+          sudo reboot
+  JoinDomainAssociationInstances:
+    Type: AWS::SSM::Association
+    Properties:
+      AssociationName: !Sub JoinDomain-Association-viaInstances-${AWS::StackName}
+      Name: AWS-JoinDirectoryServiceDomain
+      OutputLocation:
+        S3Location: !If
+          - SSMLogsBucketCondition
+          - OutputS3BucketName: !Ref SSMLogsBucketName
+            OutputS3KeyPrefix: !Sub ssm-association-logs/AWSLogs/${AWS::AccountId}/*
+          - !Ref AWS::NoValue
+      Targets:
+        - Key: InstanceIds
+          Values:
+            - !Ref DomainMember2WithSsmAssociationInstance
+            - !Ref DomainMember4LinuxWithSsmAssociationInstance
+      Parameters:
+        directoryId:
+          - !Ref DirectoryID
+        directoryName:
+          - !Ref DirectoryName
+        dnsIpAddresses: !If
+          - DomainDNSServersCondition
+          - - !If [DomainDNSServer1Condition, !Ref DomainDNSServer1, !Ref AWS::NoValue]
+            - !If [DomainDNSServer2Condition, !Ref DomainDNSServer2, !Ref AWS::NoValue]
+            - !If [DomainDNSServer3Condition, !Ref DomainDNSServer3, !Ref AWS::NoValue]
+            - !If [DomainDNSServer4Condition, !Ref DomainDNSServer4, !Ref AWS::NoValue]
+          - !Ref AWS::NoValue
+  JoinDomainAssociationTags:
+    Type: AWS::SSM::Association
+    Properties:
+      AssociationName: !Sub JoinDomain-Association-viaTags-${AWS::StackName}
+      Name: AWS-JoinDirectoryServiceDomain
+      OutputLocation:
+        S3Location: !If
+          - SSMLogsBucketCondition
+          - OutputS3BucketName: !Ref SSMLogsBucketName
+            OutputS3KeyPrefix: !Sub ssm-association-logs/AWSLogs/${AWS::AccountId}/*
+          - !Ref AWS::NoValue
+      Targets:
+        - Key: tag:DomainJoin
+          Values:
+            - !Ref DirectoryName
+      Parameters:
+        directoryId:
+          - !Ref DirectoryID
+        directoryName:
+          - !Ref DirectoryName
+        dnsIpAddresses: !If
+          - DomainDNSServersCondition
+          - - !If [DomainDNSServer1Condition, !Ref DomainDNSServer1, !Ref AWS::NoValue]
+            - !If [DomainDNSServer2Condition, !Ref DomainDNSServer2, !Ref AWS::NoValue]
+            - !If [DomainDNSServer3Condition, !Ref DomainDNSServer3, !Ref AWS::NoValue]
+            - !If [DomainDNSServer4Condition, !Ref DomainDNSServer4, !Ref AWS::NoValue]
+          - !Ref AWS::NoValue


### PR DESCRIPTION
*Description of changes:*
This solution creates Linux and Windows EC2 instances and joins them to Active Directory (AD) via AD Connector or AWS Managed AD directory via different SSM Association methods.

* `AWS-JoinDirectoryServiceDomain` SSM document is used to join AD domain.
* To join AD domain, EC2 instances must be able to resolve the AD domain, 2 options provided:
  * By default, DHCPOptionsSet is relied on to be able to resolve the AD domain.
  * If Domain DNS servers are provided, then they are set manually on the EC2 instances.
* Different methods used to initiate the Domain Join, as examples:
  * Windows EC2 instance using an inline SSM association
  * Windows and Linux EC2 instance using an SSM association resource targeting EC2 instance IDs
  * Windows EC2 instance using an SSM association resource targeting EC2 instance tags

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
