### PR TITLE
Multiple fixes for S3/CloudFront template

### DIFF
--- a/aws/services/S3/S3_Website_With_CloudFront_Distribution.yaml
+++ b/aws/services/S3/S3_Website_With_CloudFront_Distribution.yaml
@@ -1,6 +1,4 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Metadata: 
-  License: Apache-2.0
 Description: 'AWS CloudFormation Sample Template S3_Website_With_CloudFront_Distribution:
   Sample template showing how to create a website with a custom DNS name, hosted on
   Amazon S3 and served via Amazone CloudFront. It assumes you already have a Hosted
@@ -11,52 +9,76 @@ Parameters:
   HostedZone:
     Type: String
     Description: The DNS name of an existing Amazon Route 53 hosted zone
-    AllowedPattern: (?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
-    ConstraintDescription: must be a valid DNS zone name.
-Mappings:
-  Region2S3WebsiteSuffix:
-    us-east-1:
-      Suffix: .s3-website-us-east-1.amazonaws.com
-    us-west-1:
-      Suffix: .s3-website-us-west-1.amazonaws.com
-    us-west-2:
-      Suffix: .s3-website-us-west-2.amazonaws.com
-    eu-west-1:
-      Suffix: .s3-website-eu-west-1.amazonaws.com
-    ap-northeast-1:
-      Suffix: .s3-website-ap-northeast-1.amazonaws.com
-    ap-northeast-2:
-      Suffix: .s3-website-ap-northeast-2.amazonaws.com
-    ap-southeast-1:
-      Suffix: .s3-website-ap-southeast-1.amazonaws.com
-    ap-southeast-2:
-      Suffix: .s3-website-ap-southeast-2.amazonaws.com
-    ap-south-1:
-      Suffix: .s3-website-ap-south-1.amazonaws.com
-    us-east-2:
-      Suffix: .s3-website-us-east-2.amazonaws.com
-    sa-east-1:
-      Suffix: .s3-website-sa-east-1.amazonaws.com
-    cn-north-1:
-      Suffix: .s3-website.cn-north-1.amazonaws.com.cn
-    eu-central-1:
-      Suffix: .s3-website.eu-central-1.amazonaws.com
+  AcmCertificateArn:
+    Type: String
+    Description: The ARN of an existing ACM certificate (certificate domain name must
+      be in the format stacknameaccountid.region.hostedzone)
+Metadata:
+  License: Apache-2.0
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Optional parameters
+        Parameters:
+          - AcmCertificateArn
+          - HostedZone
+    ParameterLabels:
+      AcmCertificateArn:
+        default: ACM Certificate ARN
+      HostedZone:
+        default: Hosted Zone Domain Name
+Conditions:
+  HasHostedZone: !Not
+    - !Equals
+      - !Ref 'HostedZone'
+      - ''
 Resources:
+  CloudFrontOriginAccessIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: Required optional comment
   S3BucketForWebsiteContent:
     Type: AWS::S3::Bucket
+  BucketPolicy:
+    Type: AWS::S3::BucketPolicy
     Properties:
-      AccessControl: PublicRead
-      WebsiteConfiguration:
-        IndexDocument: index.html
-        ErrorDocument: error.html
+      Bucket: !Ref 'S3BucketForWebsiteContent'
+      PolicyDocument:
+        Version: '2012-10-17'
+        Id: PolicyForCloudFrontPrivateContent
+        Statement:
+          - Sid: 403Permissions
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity
+                ${CloudFrontOriginAccessIdentity}'
+            Action: "s3:ListBucket"
+            Resource: !Sub 'arn:aws:s3:::${S3BucketForWebsiteContent}'
+          - Sid: ObjectAccess
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity
+                ${CloudFrontOriginAccessIdentity}'
+            Action:
+              - s3:GetObject
+            Resource: !Sub 'arn:aws:s3:::${S3BucketForWebsiteContent}/*'
   WebsiteCDN:
     Type: AWS::CloudFront::Distribution
     Properties:
       DistributionConfig:
         Comment: CDN for S3-backed website
-        Aliases:
-        - !Join ['', [!Ref 'AWS::StackName', !Ref 'AWS::AccountId', ., !Ref 'AWS::Region',
-            ., !Ref 'HostedZone']]
+        Aliases: !If
+          - HasHostedZone
+          - - !Join
+              - ''
+              - - !Ref 'AWS::StackName'
+                - !Ref 'AWS::AccountId'
+                - .
+                - !Ref 'AWS::Region'
+                - .
+                - !Ref 'HostedZone'
+          - !Ref 'AWS::NoValue'
         Enabled: 'true'
         DefaultCacheBehavior:
           ForwardedValues:
@@ -65,27 +87,43 @@ Resources:
           ViewerProtocolPolicy: allow-all
         DefaultRootObject: index.html
         Origins:
-        - CustomOriginConfig:
-            HTTPPort: '80'
-            HTTPSPort: '443'
-            OriginProtocolPolicy: http-only
-          DomainName: !Join ['', [!Ref 'S3BucketForWebsiteContent', !FindInMap [Region2S3WebsiteSuffix,
-                !Ref 'AWS::Region', Suffix]]]
-          Id: only-origin
+          - S3OriginConfig:
+              OriginAccessIdentity: !Sub 'origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}'
+            DomainName: !Sub '${S3BucketForWebsiteContent.RegionalDomainName}'
+            Id: only-origin
+        ViewerCertificate: !If
+          - HasHostedZone
+          - AcmCertificateArn: !Ref 'AcmCertificateArn'
+            MinimumProtocolVersion: TLSv1.2_2019
+            SslSupportMethod: sni-only
+          - !Ref 'AWS::NoValue'
   WebsiteDNSName:
+    Condition: HasHostedZone
     Type: AWS::Route53::RecordSet
     Properties:
-      HostedZoneName: !Join ['', [!Ref 'HostedZone', .]]
+      HostedZoneName: !Join
+        - ''
+        - - !Ref 'HostedZone'
+          - .
       Comment: CNAME redirect custom name to CloudFront distribution
-      Name: !Join ['', [!Ref 'AWS::StackName', !Ref 'AWS::AccountId', ., !Ref 'AWS::Region',
-          ., !Ref 'HostedZone']]
+      Name: !Join
+        - ''
+        - - !Ref 'AWS::StackName'
+          - !Ref 'AWS::AccountId'
+          - .
+          - !Ref 'AWS::Region'
+          - .
+          - !Ref 'HostedZone'
       Type: CNAME
       TTL: '900'
       ResourceRecords:
-      - !GetAtt [WebsiteCDN, DomainName]
+        - !Sub '${WebsiteCDN.DomainName}'
 Outputs:
   WebsiteURL:
-    Value: !Join ['', ['http://', !Ref 'WebsiteDNSName']]
+    Value: !If
+      - HasHostedZone
+      - !Sub 'https://${WebsiteDNSName}'
+      - !Sub 'https://${WebsiteCDN.DomainName}'
     Description: The URL of the newly created website
   BucketName:
     Value: !Ref 'S3BucketForWebsiteContent'


### PR DESCRIPTION
Issue #161
Issue #192 
Issue #315

This pull request resolves the issue which prevents the S3/CloudFront template from deploying successfully (#315). The change makes supplying a hosted zone optional (so users can leverage the default CloudFront URL), but also allows users to specify a ACM ARN if they would like to specify a hosted zone. This change is backwards compatible.

All references to the S3 bucket's domain were updated to reference the bucket's regional domain which resolves the issue with the incorrect endpoints listed in the map (#161). This change also removes the need to maintain the map.

This pull request also updates the origin configuration to use a CloudFront Origin Access Identity (OAI), and the ListBucket permission was added to properly propagate 403 errors (#192) (S3 website configuration removed).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
