### PR TITLE
fix: W2531 EOL runtime (nodejs10.x) specified

### DIFF
--- a/community/services/Lambda/LambdaSample.yaml
+++ b/community/services/Lambda/LambdaSample.yaml
@@ -59,8 +59,8 @@ Resources:
     Properties:
       FunctionName:
         Fn::Sub: lambda-function-${EnvName}
-      Description: LambdaFunctioni of nodejs14.x.
-      Runtime: nodejs14.x
+      Description: LambdaFunctioni of nodejs12.x.
+      Runtime: nodejs12.x
       Code:
         ZipFile:
           "exports.handler = function(event, context){\n

--- a/community/services/Lambda/LambdaSample.yaml
+++ b/community/services/Lambda/LambdaSample.yaml
@@ -59,8 +59,8 @@ Resources:
     Properties:
       FunctionName:
         Fn::Sub: lambda-function-${EnvName}
-      Description: LambdaFunctioni of nodejs10.x.
-      Runtime: nodejs10.x
+      Description: LambdaFunctioni of nodejs14.x.
+      Runtime: nodejs14.x
       Code:
         ZipFile:
           "exports.handler = function(event, context){\n


### PR DESCRIPTION
*Description of changes:*
(similar to https://github.com/awslabs/aws-cloudformation-templates/commit/0b5c57536becd2e4301adcf426a878d0c8fbd375)

Noticed this file reporting
```
 W2531 EOL runtime (nodejs10.x) specified. Runtime is EOL since 2021-05-31 and updating will be disabled at 2021-06-30. Please consider updating to nodejs14.x
Error: ./examples/template.yml:64:7
```
(https://github.com/ScottBrenner/cfn-lint-action/pull/61/checks?check_run_id=2708313079#step:4:6, fixed with https://github.com/ScottBrenner/cfn-lint-action/pull/62)

Proposing updating to the latest runtime per https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html (untested)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
