### PR TITLE
Relicensing cfnresponse.py to Apache-2.0

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/StackMetrics/lambda/cfnresponse.py
+++ b/aws/services/CloudFormation/MacrosExamples/StackMetrics/lambda/cfnresponse.py
@@ -1,9 +1,5 @@
 #  Copyright 2016 Amazon Web Services, Inc. or its affiliates. All Rights Reserved.
-#  This file is licensed to you under the AWS Customer Agreement (the "License").
-#  You may not use this file except in compliance with the License.
-#  A copy of the License is located at http://aws.amazon.com/agreement/ .
-#  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
-#  See the License for the specific language governing permissions and limitations under the License.
+#  SPDX-License-Identifier: Apache-2.0
 
 import urllib3
 import json


### PR DESCRIPTION
*Issue #, if available:*

One of the files was under the AWS Customer Agreement.

*Description of changes:*

After obtaining internal OSPO approval, I've changed the source header to Apache-2.0. Please contact me internally if followup is needed related to the approval.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
