### PR TITLE
Fix examples

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/StringFunctions/string_example.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/StringFunctions/string_example.yaml
@@ -12,35 +12,35 @@ Resources:
         - Key: Upper
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: Upper
         - Key: Lower
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: Lower
         - Key: Capitalize
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: Capitalize
         - Key: Title
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: Title
         - Key: Replace
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: Replace
@@ -49,7 +49,7 @@ Resources:
         - Key: Strip
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: Strip
@@ -57,7 +57,7 @@ Resources:
         - Key: ShortenLeft
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: MaxLength
@@ -66,7 +66,7 @@ Resources:
         - Key: ShortenRight
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: MaxLength


### PR DESCRIPTION
These examples were wrong, if you write it as 

```
- Name: 'String'
  Parameters:
    ...
```

you get the error `AttributeError: 'list' object has no attribute 'get'`

The correct way of writing it is as a dictionary

```
  Name: 'String'
  Parameters:
    ...
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
