### PR TITLE
new sample macro DatetimeNow

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/DatetimeNow/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/DatetimeNow/README.md
@@ -1,0 +1,32 @@
+# DatetimeNow functions
+
+Provides current datetime as a formmated string.
+
+## Basic Usage
+
+Place the transform where you would like the output to be placed and provide the string format as the value for the
+format Parameter. The macro uses Python so the supported format codes match those used by the python `strftime` method.
+Full list of supported codes can be found [here](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).
+
+The example below shows return the current date time as a string in the formation 'YYYY-MM-DD hh:mm:ss' and setting it as the value
+for a tag on an s3 bucket.
+
+```yaml
+Resources:
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags:
+        - Key: DatetimeNow
+          Value:
+            'Fn::Transform':
+             - Name: 'String'
+               Parameters:
+                 param: '%Y-%m-%d %H:%M:%S'
+```
+
+## Author
+
+[Dan Johns](https://github.com/danjhd)
+Senior SA Engineer
+Amazon Web Services

--- a/aws/services/CloudFormation/MacrosExamples/DatetimeNow/datetimenow.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/DatetimeNow/datetimenow.yaml
@@ -1,0 +1,34 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+
+  TransformFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: python3.9
+      Handler: index.handler
+      MemorySize: 128
+      Timeout: 3
+      InlineCode: |
+        import datetime
+        def handler(event, context):
+            response = {
+                'requestId': event['requestId'],
+                'status': 'success'
+            }
+            try:
+                format = event['params']['format']
+                response['fragment'] = datetime.datetime.now().strftime(format)
+            except Exception as e:
+                response['status'] = 'failure'
+                response['errorMessage'] = str(e)
+            return response
+
+  Transform:
+    Type: AWS::CloudFormation::Macro
+    Properties:
+      Name: DatetimeNow
+      Description: Provides the current datetime as string in the format requested.
+      FunctionName: !GetAtt TransformFunction.Arn

--- a/aws/services/CloudFormation/MacrosExamples/DatetimeNow/datetimenow_example.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/DatetimeNow/datetimenow_example.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: tests DatetimeNow macro
+
+Resources:
+
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags:
+        - Key: DatetimeNow
+          Value:
+            'Fn::Transform':
+              - Name: DatetimeNow
+                Parameters:
+                  format: '%Y-%m-%dT%H:%M:%SZ'


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Added a new sample macro to retrieve the current Datetime as a formatted string. The format is exposed as a parameter so users can retrieve the format they prefer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
