### PR TITLE
fix typos in DatetimeNow macro readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea/
+.vscode/

--- a/aws/services/CloudFormation/MacrosExamples/DatetimeNow/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/DatetimeNow/README.md
@@ -1,6 +1,6 @@
 # DatetimeNow functions
 
-Provides the current datetime as a formated string.
+Provides the current datetime as a formatted string.
 
 ## Basic Usage
 

--- a/aws/services/CloudFormation/MacrosExamples/DatetimeNow/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/DatetimeNow/README.md
@@ -1,14 +1,14 @@
 # DatetimeNow functions
 
-Provides current datetime as a formmated string.
+Provides the current datetime as a formated string.
 
 ## Basic Usage
 
 Place the transform where you would like the output to be placed and provide the string format as the value for the
-format Parameter. The macro uses Python so the supported format codes match those used by the python `strftime` method.
-Full list of supported codes can be found [here](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).
+`format` Parameter. The macro uses Python so the supported format codes match those used by the python `strftime` method.
+A Full list of supported codes can be found [here](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).
 
-The example below shows return the current date time as a string in the formation 'YYYY-MM-DD hh:mm:ss' and setting it as the value
+The example below shows retrieving the current date time as a string in the format 'YYYY-MM-DD hh:mm:ss' and setting it as the value
 for a tag on an s3 bucket.
 
 ```yaml


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Fix typos in readme for the DatetimeNow macro.
Also added .vscode folder to .gitignore.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
