### PR TITLE
Adding support for URL as a source

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/S3Objects/example.template
+++ b/aws/services/CloudFormation/MacrosExamples/S3Objects/example.template
@@ -38,3 +38,11 @@ Resources:
         Bucket: !Ref Bucket
         Key: README-copy.md
         ACL: public-read
+
+  Object4:
+    Type: AWS::S3::Object
+    Properties:
+      Target:
+        Bucket: !Ref Bucket
+        Key: nics-firearm-background-checks.csv
+      URL: https://raw.githubusercontent.com/BuzzFeedNews/nics-firearm-background-checks/master/data/nics-firearm-background-checks.csv

--- a/aws/services/CloudFormation/MacrosExamples/S3Objects/lambda/macro.py
+++ b/aws/services/CloudFormation/MacrosExamples/S3Objects/lambda/macro.py
@@ -31,13 +31,13 @@ def handle_template(request_id, template):
                     [
                         prop
                         for prop in resource["Properties"]
-                        if prop in ["Body", "Base64Body", "Source"]
+                        if prop in ["Body", "URL", "Base64Body", "Source"]
                     ]
                 )
                 != 1
             ):
                 raise Exception(
-                    "You must specify exactly one of: Body, Base64Body, Source"
+                    "You must specify exactly one of: Body, URL, Base64Body, Source"
                 )
 
             target = props["Target"]
@@ -52,6 +52,9 @@ def handle_template(request_id, template):
 
             if "Body" in props:
                 resource_props["Body"] = props["Body"]
+
+            elif "URL" in props:
+                resource_props["URL"] = props["URL"]
 
             elif "Base64Body" in props:
                 resource_props["Base64Body"] = props["Base64Body"]

--- a/aws/services/CloudFormation/MacrosExamples/S3Objects/lambda/resource.py
+++ b/aws/services/CloudFormation/MacrosExamples/S3Objects/lambda/resource.py
@@ -16,6 +16,7 @@ import base64
 import boto3
 import http.client
 import json
+import urllib.request
 
 s3_client = boto3.client("s3")
 
@@ -55,7 +56,7 @@ def handler(event, context):
     properties = event["ResourceProperties"]
 
     if "Target" not in properties or all(
-        prop not in properties for prop in ["Body", "Base64Body", "Source"]
+        prop not in properties for prop in ["Body", "URL", "Base64Body", "Source"]
     ):
         return sendResponse(event, context, "FAILED", "Missing required parameters")
 
@@ -66,6 +67,19 @@ def handler(event, context):
             target.update(
                 {
                     "Body": properties["Body"],
+                }
+            )
+
+            s3_client.put_object(**target)
+
+        elif "URL" in properties:
+
+            with urllib.request.urlopen(properties['URL']) as f:
+                content = f.read().decode('utf-8')
+
+            target.update(
+                {
+                    "Body": content,
                 }
             )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds support to specify a URL as a source for the S3Object macro. The macro will then download the file and upload to the specified target


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
