### PR TITLE
Fix aws config template

### DIFF
--- a/aws/services/Config/Config.yaml
+++ b/aws/services/Config/Config.yaml
@@ -101,7 +101,7 @@ Resources:
           var config = new aws.ConfigService();
           var ec2 = new aws.EC2();
           exports.handler = function(event, context) {
-              compliance = evaluateCompliance(event, function(compliance, event) {
+              var compliance = evaluateCompliance(event, function(compliance, event) {
                   var configurationItem = JSON.parse(event.invokingEvent).configurationItem;
                   var putEvaluationsRequest = {
                       Evaluations: [{
@@ -161,7 +161,7 @@ Resources:
           Principal:
             Service: [config.amazonaws.com]
           Action: ['sts:AssumeRole']
-      ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWSConfigRole']
+      ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWS_ConfigRole']
       Policies:
       - PolicyName: root
         PolicyDocument:


### PR DESCRIPTION
## Description of changes
- Fix syntax in lambda implementation
- Replace deprecated AWSConfigRole with AWS_ConfigRole
	- See: https://docs.aws.amazon.com/config/latest/developerguide/security-iam-awsmanpol.html#security-iam-awsmanpol-updates

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
