### PR TITLE
Added Macro Example 'FindVPCResourceIds'

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/FindVPCResourceIds/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/FindVPCResourceIds/README.md
@@ -1,0 +1,113 @@
+# AWS CloudFormation Macro to find VPC ResourceId(s) by tags
+Large organizations often provision VPC and related resources via a centralized provisioning mechanisms. Application teams need a simple method to identify and use these VPC resources in their AWS CloudFormation template. Tagging is a good mechanism to uniquely identify the VPC resources for the target purpose. For example:
+```
+# VPC for project->myp environment->dev
+Tags:
+- Key: Project
+  Value: myp
+- Key: Env
+  Value: dev
+
+# VPC for project->myp environment->qa
+Tags:
+- Key: Project
+  Value: myp
+- Key: Env
+  Value: qa
+```
+This [Macro](https://gitlab.aws.dev/vivgoyal/aws-cfn-macro-samples/tree/main/FindVPCResourceIds) can be used to find following VPC ResourceId(s) by tags.
+- VpcId
+- SubnetIds
+- SecurityGroupIds
+
+The macro can be used via `Fn::Transform`. For example:
+```
+rSampleSG:
+  Type: AWS::EC2::SecurityGroup
+  Properties:
+    # ...
+    VpcId:
+      Fn::Transform:
+        Name: FindVPCResourceIdsByTags
+        Parameters:
+          ResourceType: VpcId # Find VpcId
+          #Search by following tags
+          Project: myp
+          Env: dev
+    # ...
+rALB:
+  Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+  Properties:
+    Type: application
+    #...
+    Subnets:
+      Fn::Transform:
+        Name: FindVPCResourceIdsByTags
+        Parameters:
+          ResourceType: SubnetIds # Find SubnetIds
+          ReturnType: StringList  # Return StringList
+          #Search VPC by following tags (VPC::<tag>)
+          VPC::Project: myp
+          VPC::Env: dev
+          #Search Subnets by following tags
+          ALB: 1
+          Project: myp
+          Env: env
+    IpAddressType: ipv4
+    SecurityGroups:
+      Fn::Transform:
+        Name: FindVPCResourceIdsByTags
+        Parameters:
+          ResourceType: SecurityGroupIds # Find SecurityGroupIds
+          ReturnType: StringList  # Return StringList
+          #Search VPC by following tags (VPC::<tag>)
+          VPC::Project: myp
+          VPC::Env: dev
+          #Search SecurityGroups by following tags
+          ALB: 1
+          Project: myp
+          Env: env
+    #...
+```
+<div style="page-break-after: always;"></div>
+
+## Deployment
+- Deploy the `macro.yaml` template to a CloudFormation stack e.g. "myp-dev-FindVPCResources-macro"
+  ```bash
+  aws cloudformation deploy --stack-name myp-dev-FindVPCResources-macro --template-file ./macro.yaml --capabilities CAPABILITY_NAMED_IAM
+  ```
+- Deploy the `example.yaml` template to a CloudFormation stack e.g. "myp-dev-FindVPCResources-example". **Make sure VPC, Subnet(s), and Security Groups exist and tagged.**
+  ```bash
+  aws cloudformation deploy --stack-name myp-dev-FindVPCResources-example --template-file ./example.yaml
+  ```
+## Cleanup
+- Delete the "myp-dev-FindVPCResources-example" stack.
+  ```bash
+  aws cloudformation delete-stack --stack-name myp-dev-FindVPCResources-example
+  ```
+- Delete the "myp-dev-FindVPCResources-macro" stack.
+  ```bash
+  aws cloudformation delete-stack --stack-name myp-dev-FindVPCResources-macro
+  ```
+<div style="page-break-after: always;"></div>
+
+## Usage
+The macro can be used to find following VPC ResourceId(s) by tags.
+- VpcId
+- SubnetIds
+- SecurityGroupIds
+
+Following table describes the parameters that control the behavior of the macro.
+| Parameter | Mandatory | Value | Behavior |
+| --------- | --------- | --------------- | ----------- |
+| ResourceType | Yes | VpcId | Return a single matching VpcId (String). If multiple found, return one. |
+| ResourceType | Yes | SubnetIds | Return one ore more matching SubnetIds (StringList/String). |
+| ResourceType | Yes | SecurityGroupIds | Return one ore more SecurityGroupIds (StringList/String). |
+| ReturnType | No (Default: StringList) | String | Return comma delimited string. |
+| ReturnType | No (Default: StringList) | StringList | Return list of strings. |
+| TagKey: TagValue | Yes | any: any | Find the requested `ResourceType` by matching tags.<br/>To find SubnetIds and SecurityGroupIds within a VPC, specify the VPC tags by prefixing it with "VPC::". |
+
+## Security
+See [CONTRIBUTING](https://gitlab.aws.dev/vivgoyal/aws-cfn-macro-samples/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information.
+## License
+This library is licensed under the MIT-0 License. See the [LICENSE](https://gitlab.aws.dev/vivgoyal/aws-cfn-macro-samples/blob/main/LICENSE) file.

--- a/aws/services/CloudFormation/MacrosExamples/FindVPCResourceIds/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/FindVPCResourceIds/README.md
@@ -15,7 +15,7 @@ Tags:
 - Key: Env
   Value: qa
 ```
-This [Macro](https://gitlab.aws.dev/vivgoyal/aws-cfn-macro-samples/tree/main/FindVPCResourceIds) can be used to find following VPC ResourceId(s) by tags.
+This Macro can be used to find following VPC ResourceId(s) by tags.
 - VpcId
 - SubnetIds
 - SecurityGroupIds
@@ -107,7 +107,8 @@ Following table describes the parameters that control the behavior of the macro.
 | ReturnType | No (Default: StringList) | StringList | Return list of strings. |
 | TagKey: TagValue | Yes | any: any | Find the requested `ResourceType` by matching tags.<br/>To find SubnetIds and SecurityGroupIds within a VPC, specify the VPC tags by prefixing it with "VPC::". |
 
-## Security
-See [CONTRIBUTING](https://gitlab.aws.dev/vivgoyal/aws-cfn-macro-samples/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information.
-## License
-This library is licensed under the MIT-0 License. See the [LICENSE](https://gitlab.aws.dev/vivgoyal/aws-cfn-macro-samples/blob/main/LICENSE) file.
+## Authors
+
+[Vivek Goyal](https://github.com/vivgoyal-aws) AWS ProServ Sr. Cloud Infrastructure Architect
+
+

--- a/aws/services/CloudFormation/MacrosExamples/FindVPCResourceIds/example.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/FindVPCResourceIds/example.yaml
@@ -1,0 +1,146 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >
+  This CloudFormation template for testing macro
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    #Define user friendly Parameter Groups
+    ParameterGroups:
+      - Label:
+          default: Project Configuration
+        Parameters:
+          - pProject
+          - pEnv
+    #Define user friendly names for the parameters
+    ParameterLabels:
+      pProject:
+        default: Project name
+      pEnv:
+        default: Environment
+
+Parameters:
+  pProject:
+    Description: The project name e.g. myp.
+    Type: String
+    Default: myp
+  pEnv:
+    Description: The environment identifier e.g. DEV
+    Type: String
+    Default: dev
+
+Resources:
+  rParamVPCId:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: !Sub "VPC Id for the project ${pProject} environment ${pEnv}."
+      Name: !Sub "/${pProject}/${pEnv}/vpc-id"
+      Type: String
+      Value:
+        Fn::Transform:
+          Name: FindVPCResourceIds
+          Parameters:
+            ResourceType: VpcId
+            #Search by following tags
+            Project: !Ref pProject
+            Env: !Ref pEnv
+      Tags:
+        Project: !Ref pProject
+        Env: !Ref pEnv
+        CreatedBy: !Ref AWS::StackId
+  rParamSubnetIds:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: !Sub "Subnet Ids for the project ${pProject} environment ${pEnv}."
+      Name: !Sub "/${pProject}/${pEnv}/subnet-ids"
+      Type: StringList
+      Value:
+        Fn::Transform:
+          Name: FindVPCResourceIds
+          Parameters:
+            ResourceType: SubnetIds
+            ReturnType: String # or StringList
+            #Search VPC by following tags VPC::<tag-name>
+            VPC::Project: !Ref pProject
+            VPC::Env: !Ref pEnv
+            #Search Subnets by following tags
+            Project: !Ref pProject
+            Env: !Ref pEnv
+            Private: 1
+      Tags:
+        Project: !Ref pProject
+        Env: !Ref pEnv
+        CreatedBy: !Ref AWS::StackId
+  rParamSecurityGroupIds:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: !Sub "Security Group Ids for the project ${pProject} environment ${pEnv}."
+      Name: !Sub "/${pProject}/${pEnv}/security-group-ids"
+      Type: StringList
+      Value:
+        Fn::Transform:
+          Name: FindVPCResourceIds
+          Parameters:
+            ResourceType: SecurityGroupIds
+            ReturnType: String # or StringList
+            #Search VPC by following tags VPC::<tag-name>
+            VPC::Project: !Ref pProject
+            VPC::Env: !Ref pEnv
+            #Search Subnets by following tags
+            Project: !Ref pProject
+            Env: !Ref pEnv
+            VPCE: 1
+      Tags:
+        Project: !Ref pProject
+        Env: !Ref pEnv
+        CreatedBy: !Ref AWS::StackId
+
+  rSampleSG:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: "SG Name is used for identification, it is OK to replace"
+          - id: W5
+            reason: "Allow https outbound to world"
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: !Sub ${pProject}-${pEnv}-sample-sg
+      GroupDescription: Sample Security Group.
+      VpcId:
+        Fn::Transform:
+          Name: FindVPCResourceIdsByTags
+          Parameters:
+            ResourceType: VpcId
+            #Search by following tags
+            Project: !Ref pProject
+            Env: !Ref pEnv
+      SecurityGroupEgress:
+        - Description: Allow https outbound
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Project
+          Value: !Ref pProject
+        - Key: Env
+          Value: !Ref pEnv
+
+Outputs:
+  oVPCId:
+    Description: VPC Id.
+    Value: !GetAtt rParamVPCId.Value
+    Export:
+      Name: !Sub "${AWS::StackName}-VPCId"
+  oSubnetIds:
+    Description: Subnet Ids."
+    Value: !GetAtt rParamSubnetIds.Value
+    Export:
+      Name: !Sub "${AWS::StackName}-SubnetIds"
+  oSampleSGId:
+    Description: Security Group Id.
+    Value: !GetAtt rSampleSG.GroupId
+    Export:
+      Name: !Sub "${AWS::StackName}-SampleSGId"

--- a/aws/services/CloudFormation/MacrosExamples/FindVPCResourceIds/macro.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/FindVPCResourceIds/macro.yaml
@@ -1,0 +1,235 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >
+  This CloudFormation template is to provision the CloudFormation macro that find supported VPC ResourceId(s) by tags
+  1. Lambda Execution role is created.
+  2. Lambda is created that implements the macro logic.
+  3. Macro is created that uses the Lambda
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    #Define user friendly Parameter Groups
+    ParameterGroups:
+      - Label:
+          default: Project Configuration
+        Parameters:
+          - pProject
+          - pEnv
+    #Define user friendly names for the parameters
+    ParameterLabels:
+      pProject:
+        default: Project name
+      pEnv:
+        default: Environment
+
+Parameters:
+  pProject:
+    Description: The project name e.g. myp.
+    Type: String
+    Default: myp
+  pEnv:
+    Description: The environment identifier e.g. dev
+    Type: String
+    Default: dev
+
+
+Resources:
+  rMacroLambdaExecRole:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: "Role Name is used for identification, it is OK to replace"
+          - id: W11
+            reason: "Only 'Describe*' is allowed"
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub cfn-macro-find-vpc-resource-exec-role-${pProject}-${pEnv}
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: "/"
+      #PermissionsBoundary: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/Permission_Boundary_if_any
+      Policies:
+        - PolicyName: lambda-cw-access
+          PolicyDocument:
+            Statement:
+              - Sid: LambdaAccessForCWLogGroup
+                Effect: Allow
+                Action: logs:CreateLogGroup
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
+              - Sid: LambdaAccessForCWLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*
+        - PolicyName: lambda-ec2-access
+          PolicyDocument:
+            Statement:
+              - Sid: LambdaEC2Access
+                Effect: Allow
+                Action:
+                  - ec2:Describe*
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: !Ref pProject
+        - Key: Env
+          Value: !Ref pEnv
+        - Key: CreatedBy
+          Value: !Ref AWS::StackId
+
+  rFindVPCResourceIdsFunction:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: "VPC Access not required"
+          - id: W58
+            reason: "Permission to write CloudWatch logs is provided via execution role in security template"
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Description: "Find supported VPCResource(s) Id(s) by tags"
+      FunctionName: !Sub cfn-macro-find-vpc-resource-${pProject}-${pEnv}
+      Handler: index.handler
+      Role: !GetAtt "rMacroLambdaExecRole.Arn"
+      Timeout: 120
+      Runtime: python3.9
+      ReservedConcurrentExecutions: 2
+      Code:
+        ZipFile: |
+          import json
+          import boto3
+
+          vpc_client = boto3.client('ec2')
+
+          def handle_filters(params):
+              filters = []
+              for k in params :
+                  filters.append(
+                      {
+                          "Name": f"tag:{k}",
+                          "Values": [ str(params[k]) ]
+                      }
+                  )
+              return filters
+
+          def find_vpc_id(params):
+              result = ""
+              #Search for VPC
+              try:
+                  filters = handle_filters(params)
+                  vpcs = vpc_client.describe_vpcs( Filters=filters, MaxResults=5 )
+                  if len(vpcs["Vpcs"]) > 0 :
+                      result = vpcs["Vpcs"][0]["VpcId"]
+              except Exception as e:
+                  print( str(e) )
+              return result
+
+          def find_subnet_ids(vpc_id, params):
+              result = []
+              #Search for SubnetIds
+              try:
+                  filters = handle_filters(params)
+                  filters.append(
+                      {
+                          "Name": "vpc-id",
+                          "Values": [ vpc_id ]
+                      }
+                  )
+
+                  subnets = vpc_client.describe_subnets( Filters=filters, MaxResults=6 )
+                  for subnet in subnets["Subnets"]:
+                      result.append(subnet["SubnetId"])
+              except Exception as e:
+                  print( str(e) )
+              return result
+
+          def find_sg_ids(vpc_id, params):
+              result = []
+              #Search for SecurityGroupIds
+              try:
+                  filters = handle_filters(params)
+                  filters.append(
+                      {
+                          "Name": "vpc-id",
+                          "Values": [ vpc_id ]
+                      }
+                  )
+
+                  sgs = vpc_client.describe_security_groups( Filters=filters, MaxResults=6 )
+                  for sg in sgs["SecurityGroups"]:
+                      result.append(sg["GroupId"])
+              except Exception as e:
+                  print( str(e) )
+              return result
+
+          def handler(event, context):
+              print( json.dumps(event, indent=2))
+
+              status = "success"
+              fragment = event["fragment"]
+              templateParameterValues = event["params"]
+              params = event["params"]
+
+              resource_type = params.pop("ResourceType")
+
+              return_type = "StringList"
+              if "ReturnType" in params :
+                return_type = params.pop("ReturnType")
+
+              if resource_type == "VpcId":
+                  fragment = find_vpc_id(params)
+              elif resource_type == "SubnetIds":
+                  vpc_params = {}
+                  subnet_params = {}
+                  for k in params :
+                      if k.startswith("VPC::"):
+                          vpc_params[k.replace("VPC::", "")] = params[k]
+                      else:
+                          subnet_params[k] = params[k]
+                  result = find_subnet_ids(find_vpc_id(vpc_params), subnet_params)
+                  if return_type == 'String' :
+                    fragment = ",".join(result)
+                  else :
+                    fragment = result
+              elif resource_type == "SecurityGroupIds":
+                  vpc_params = {}
+                  sg_params = {}
+                  for k in params :
+                      if k.startswith("VPC::"):
+                          vpc_params[k.replace("VPC::", "")] = params[k]
+                      else:
+                          sg_params[k] = params[k]
+                  result = find_sg_ids(find_vpc_id(vpc_params), sg_params)
+                  if return_type == 'String' :
+                    fragment = ",".join(result)
+                  else :
+                    fragment = result
+
+              return {
+                  "requestId": event["requestId"],
+                  "status": status,
+                  "fragment": fragment,
+              }
+      Tags:
+        - Key: Project
+          Value: !Ref pProject
+        - Key: Env
+          Value: !Ref pEnv
+        - Key: CreatedBy
+          Value: !Ref AWS::StackId
+
+  mFindVPCResourceIds:
+    Type: AWS::CloudFormation::Macro
+    Properties:
+      Name: FindVPCResourceIds
+      Description: Find supported VPC ResourceId(s) by tags
+      FunctionName: !GetAtt rFindVPCResourceIdsFunction.Arn


### PR DESCRIPTION
*Description of changes: Macro example added 'FindVPCResourceIDs'*

This CloudFormation Macro can be used to find following VPC ResourceId(s) by tags.
- VpcId
- SubnetIds
- SecurityGroupIds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
