### PR TITLE
added MacrosExamples 'MergeStatements' and 'MergeTags'

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/MergeStatements/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/MergeStatements/README.md
@@ -1,0 +1,249 @@
+# AWS CloudFormation Macro to merge IAM policy statements
+Often resource policies (e.g. KMS resource policy, S3 resource policy) have common IAM policy statements that need to be applied to multiple IAM policies. These common IAM policy statements make the code repetitive and hard to change.
+
+For example, each AWS KMS key should have policy statements for the KMS administrator's access.
+```yaml
+# ...
+Resources:
+  rS3KMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: AWS KMS key for encrypting Amazon S3
+      KeyPolicy:
+        Id: kms-key-s3
+        Version: '2012-10-17'
+        Statement:
+        # Common for each key
+        - Sid: Allow access for Key Administrators
+          Effect: Allow
+          Principal:
+            AWS: !Ref pKMSAdminRoles
+          Action:
+          - kms:Create*
+          #...
+          Resource: "*"
+        # Common for each key
+        - Sid: Allow granting of the key to Key Administrators
+          Effect: Allow
+          Principal:
+            AWS: !Ref pKMSAdminRoles
+          Action:
+          - kms:CreateGrant
+          #...
+          Resource: "*"
+          Condition:
+            #...
+        # Common for each key
+        - Sid: Allow direct access to key metadata to the account
+          Effect: Allow
+          Principal:
+            AWS: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:root
+          Action:
+          - kms:Describe*
+          #...
+          Resource: "*"
+        # S3 specific
+        - Sid: Allow access through Amazon S3 for all principals in the account that are authorized to use Amazon S3
+          Effect: Allow
+          Principal:
+            AWS: "*"
+          Action:
+          - kms:Encrypt
+          #...
+          Resource: "*"
+          Condition:
+            #...
+      KeySpec: SYMMETRIC_DEFAULT
+      #...
+# ...
+```
+This Macro can be used to merge multiple IAM policy statements from a set of statement files.
+
+The macro can be used via `Fn::Transform`. For example:
+```yaml
+# ...
+Resources:
+  rS3KMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: AWS KMS key for encrypting Amazon S3
+      KeyPolicy:
+        Id: kms-key-s3
+        Version: '2012-10-17'
+        Statement:
+          Fn::Transform:
+            Name: MergeStatements
+            Parameters:
+              #Merge statements in these files
+              Files: !Sub templates/${pEnv}/kms-admin.json,templates/${pEnv}/kms-s3.json
+      KeySpec: SYMMETRIC_DEFAULT
+      #...
+  rMWAAKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: AWS KMS key for encrypting Amazon MWAA
+      KeyPolicy:
+        Id: kms-key-mwaa
+        Version: "2012-10-17"
+        Statement:
+          Fn::Transform:
+            Name: MergeStatements
+            Parameters:
+              #Merge statements in these files
+              Files: !Sub templates/${pEnv}/kms-admin.json,templates/${pEnv}/kms-s3.json,templates/${pEnv}/kms-logs.json,templates/${pEnv}/kms-mwaa.json
+      KeySpec: SYMMETRIC_DEFAULT
+      #...
+# ...
+```
+Here, the `Files` parameter points to comma delimited list of `json` files that define the IAM policy statement. For example:
+```json
+{
+    "Statement": [
+        {
+            "Sid": "Allow access for Key Administrators",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": {
+                    "Ref": "pKMSAdminRoles"
+                }
+            },
+            "Action": [
+                "kms:Create*",
+                #...
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow granting of the key to Key Administrators",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": {
+                    "Ref": "pKMSAdminRoles"
+                }
+            },
+            "Action": [
+                "kms:CreateGrant",
+                #...
+            ],
+            "Resource": "*",
+            "Condition": {
+              #...
+            }
+        },
+        {
+            "Sid": "Allow direct access to key metadata to the account",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+                }
+            },
+            "Action": [
+                "kms:Describe*",
+                #...
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+<div style="page-break-after: always;"></div>
+
+## Deployment
+- Provide the parameters, as per your environment, in `params.json` parameter file. Provide the name of an existing bucket in `pBucketName`, and ARNs of KMS admin roles in `pKMSAdminRoles`
+  ```json
+  [
+    {
+      "ParameterKey": "pBucketName",
+      "ParameterValue": "<your-template-bucket>"
+    },
+    {
+        "ParameterKey": "pKMSAdminRoles",
+        "ParameterValue": "<comma-delimited-list-of-admin-role-arns>"
+    },
+    {
+      "ParameterKey": "pProject",
+      "ParameterValue": "myp"
+    },
+    {
+      "ParameterKey": "pEnv",
+      "ParameterValue": "dev"
+    }
+  ]
+  ```
+- Deploy the `macro.yaml` template to a CloudFormation stack e.g. "myp-dev-MergeStatements-macro"
+  ```bash
+  aws cloudformation deploy --stack-name myp-dev-MergeStatements-macro --template-file ./macro.yaml --parameter-overrides file://params.json --capabilities CAPABILITY_NAMED_IAM
+  ```
+- Copy the sample statement files to bucket. For example:
+  ```bash
+  aws s3 cp kms-admin.json s3://${pBucketName}/templates/${pEnv}/kms-admin.json
+  aws s3 cp kms-s3.json s3://${pBucketName}/templates/${pEnv}/kms-s3.json
+  aws s3 cp kms-logs.json s3://${pBucketName}/templates/${pEnv}/kms-logs.json
+  aws s3 cp kms-mwaa.json s3://${pBucketName}/templates/${pEnv}/kms-mwaa.json
+  ```
+- Deploy the `example.yaml` template to a CloudFormation stack e.g. "myp-dev-MergeStatements-example".
+  ```bash
+  aws cloudformation deploy --stack-name myp-dev-MergeStatements-example --template-file ./example.yaml --parameter-overrides file://params.json
+  ```
+- Verify the merged key policy on the [AWS KMS console](https://console.aws.amazon.com/kms/home?region=us-east-1#/kms/keys)
+
+## Cleanup
+- Delete the "myp-dev-MergeStatements-example" stack.
+  ```bash
+  aws cloudformation delete-stack --stack-name myp-dev-MergeStatements-example
+  ```
+- Delete the "myp-dev-MergeStatements-macro" stack.
+  ```bash
+  aws cloudformation delete-stack --stack-name myp-dev-MergeStatements-macro
+  ```
+
+## Usage
+- Use the macro via the `Fn::Transform` function for any AWS CloudFormation resource that expects IAM policy document. For example:
+  ```yaml
+  # ...
+  KeyPolicy:
+    Id: kms-key-mwaa
+    Version: "2012-10-17"
+    Statement:
+      Fn::Transform:
+        Name: MergeStatements
+        Parameters:
+          #Merge statements in these files
+          Files: !Sub templates/${pEnv}/kms-admin.json,templates/${pEnv}/kms-s3.json,templates/${pEnv}/kms-logs.json,templates/${pEnv}/kms-mwaa.json
+  # ...
+  ```
+- `Files` parameter is the only mandatory parameter. It points to comma delimited list of `json` files that define the IAM policy statement.
+  - Statements in the `json` file may also be parameterized, using the intrinsic function [Ref](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html) and [Sub](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html). For example:
+  ```json
+  {
+    "Statement": [
+      {
+        "Sid": "Allow access through Amazon S3 for all principals in the account that are authorized to use Amazon S3",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "*"
+        },
+        "Action": [
+          "kms:Encrypt",
+          # ...
+        ],
+        "Resource": "*",
+        "Condition": {
+          "StringEquals": {
+            "kms:CallerAccount": {
+              "Ref": "AWS::AccountId"
+            },
+            "kms:ViaService": {
+              "Fn::Sub": "s3.${AWS::Region}.amazonaws.com"
+            }
+          }
+        }
+      }
+    ]
+  }
+  ```
+## Authors
+
+[Vivek Goyal](https://github.com/vivgoyal-aws) AWS ProServ Sr. Cloud Infrastructure Architect

--- a/aws/services/CloudFormation/MacrosExamples/MergeStatements/example.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/MergeStatements/example.yaml
@@ -1,0 +1,157 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >
+  This CloudFormation template for testing macro
+
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E3002 #used via transform
+        - E2507 #used via transform
+        - W2001 #used via transform
+  AWS::CloudFormation::Interface:
+    #Define user friendly Parameter Groups
+    ParameterGroups:
+      - Label:
+          default: Project Configuration
+        Parameters:
+          - pKMSAdminRoles
+          - pProject
+          - pEnv
+    #Define user friendly names for the parameters
+    ParameterLabels:
+      pKMSAdminRoles:
+        default: AWS KMS Key admin role ARNs
+      pProject:
+        default: Project name
+      pEnv:
+        default: Environment
+
+Parameters:
+  #Referred in the Statement files
+  pKMSAdminRoles:
+    Description: >
+      Provide comma separated IAM Role ARNs that has Admin access to the created AWS KMS key(s).
+    Type: CommaDelimitedList
+  pProject:
+    Description: The project name e.g. myp.
+    Type: String
+    Default: myp
+  pEnv:
+    Description: The environment identifier e.g. DEV
+    Type: String
+    Default: dev
+
+Resources:
+  rS3KMSKey:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: F76
+            reason: "Principal * is used with condition"
+    Type: AWS::KMS::Key
+    Properties:
+      Description: AWS KMS key for encrypting Amazon S3
+      Enabled: true
+      EnableKeyRotation: true
+      KeySpec: SYMMETRIC_DEFAULT
+      KeyUsage: ENCRYPT_DECRYPT
+      MultiRegion: false
+      PendingWindowInDays: 7
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: kms-key-s3
+        Statement:
+          Fn::Transform:
+            Name: MergeStatements
+            Parameters:
+              #Merge statements in these files
+              Files: !Sub templates/${pEnv}/kms-admin.json,templates/${pEnv}/kms-s3.json
+      Tags:
+        - Key: Project
+          Value: !Ref pProject
+        - Key: Env
+          Value: !Ref pEnv
+        - Key: CreatedBy
+          Value: !Ref AWS::StackId
+  rS3KMSKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub alias/${pProject}/example/s3
+      TargetKeyId: !Ref rS3KMSKey
+
+  rMWAAKMSKey:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: F76
+            reason: "Principal * is used with condition"
+    Type: AWS::KMS::Key
+    Properties:
+      Description: AWS KMS key for encrypting Amazon MWAA
+      Enabled: true
+      EnableKeyRotation: true
+      KeySpec: SYMMETRIC_DEFAULT
+      KeyUsage: ENCRYPT_DECRYPT
+      MultiRegion: false
+      PendingWindowInDays: 7
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: kms-key-mwaa
+        Statement:
+          Fn::Transform:
+            Name: MergeStatements
+            Parameters:
+              #Merge statements in these files
+              Files: !Sub templates/${pEnv}/kms-admin.json,templates/${pEnv}/kms-s3.json,templates/${pEnv}/kms-logs.json,templates/${pEnv}/kms-mwaa.json
+      Tags:
+        - Key: Project
+          Value: !Ref pProject
+        - Key: Env
+          Value: !Ref pEnv
+        - Key: CreatedBy
+          Value: !Ref AWS::StackId
+  rMWAAKMSKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub alias/${pProject}/example/mwaa
+      TargetKeyId: !Ref rMWAAKMSKey
+
+  rLogsKMSKey:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: F76
+            reason: "Principal * is used with condition"
+    Type: AWS::KMS::Key
+    Properties:
+      Description: AWS KMS key for encrypting Amazon CloudWatch logs
+      Enabled: true
+      EnableKeyRotation: true
+      KeySpec: SYMMETRIC_DEFAULT
+      KeyUsage: ENCRYPT_DECRYPT
+      MultiRegion: false
+      PendingWindowInDays: 7
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: kms-key-ebs
+        Statement:
+          Fn::Transform:
+            Name: MergeStatements
+            Parameters:
+              #Merge statements in these files
+              Files: !Sub templates/${pEnv}/kms-admin.json,templates/${pEnv}/kms-logs.json
+      Tags:
+        - Key: Project
+          Value: !Ref pProject
+        - Key: Env
+          Value: !Ref pEnv
+        - Key: CreatedBy
+          Value: !Ref AWS::StackId
+  rLogsKMSKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub alias/${pProject}/example/logs
+      TargetKeyId: !Ref rLogsKMSKey

--- a/aws/services/CloudFormation/MacrosExamples/MergeStatements/kms-admin.json
+++ b/aws/services/CloudFormation/MacrosExamples/MergeStatements/kms-admin.json
@@ -1,0 +1,66 @@
+{
+    "Statement": [
+        {
+            "Sid": "Allow access for Key Administrators",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": {
+                    "Ref": "pKMSAdminRoles"
+                }
+            },
+            "Action": [
+                "kms:Create*",
+                "kms:Describe*",
+                "kms:Enable*",
+                "kms:List*",
+                "kms:Put*",
+                "kms:Update*",
+                "kms:Revoke*",
+                "kms:Disable*",
+                "kms:Get*",
+                "kms:Delete*",
+                "kms:TagResource",
+                "kms:UntagResource",
+                "kms:ScheduleKeyDeletion",
+                "kms:CancelKeyDeletion"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow granting of the key to Key Administrators",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": {
+                    "Ref": "pKMSAdminRoles"
+                }
+            },
+            "Action": [
+                "kms:CreateGrant",
+                "kms:ListGrants",
+                "kms:RevokeGrant"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": true
+                }
+            }
+        },
+        {
+            "Sid": "Allow direct access to key metadata to the account",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+                }
+            },
+            "Action": [
+                "kms:Describe*",
+                "kms:Get*",
+                "kms:List*",
+                "kms:RevokeGrant"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/aws/services/CloudFormation/MacrosExamples/MergeStatements/kms-logs.json
+++ b/aws/services/CloudFormation/MacrosExamples/MergeStatements/kms-logs.json
@@ -1,0 +1,29 @@
+{
+    "Statement": [
+        {
+            "Sid": "Allow access to the service CloudWatch Logs",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": {
+                    "Fn::Sub": "logs.${AWS::Region}.amazonaws.com"
+                }
+            },
+            "Action": [
+                "kms:Encrypt*",
+                "kms:Decrypt*",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:Describe*",
+                "kms:CreateGrant"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "ArnLike": {
+                    "kms:EncryptionContext:aws:logs:arn": {
+                        "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/aws/services/CloudFormation/MacrosExamples/MergeStatements/kms-mwaa.json
+++ b/aws/services/CloudFormation/MacrosExamples/MergeStatements/kms-mwaa.json
@@ -1,0 +1,34 @@
+{
+    "Statement": [
+        {
+            "Sid": "Allow access for use on MWAA SQS",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": [
+                "kms:Encrypt*",
+                "kms:Decrypt*",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:Describe*"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "kms:CallerAccount": {
+                        "Ref": "AWS::AccountId"
+                    },
+                    "kms:ViaService": {
+                        "Fn::Sub": "airflow.${AWS::Region}.amazonaws.com"
+                    }
+                },
+                "ArnLike": {
+                    "kms:EncryptionContext:aws:sqs:arn": {
+                        "Fn::Sub": "arn:${AWS::Partition}:sqs:${AWS::Region}:*:airflow-celery-*"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/aws/services/CloudFormation/MacrosExamples/MergeStatements/kms-s3.json
+++ b/aws/services/CloudFormation/MacrosExamples/MergeStatements/kms-s3.json
@@ -1,0 +1,29 @@
+{
+    "Statement": [
+        {
+            "Sid": "Allow access through Amazon S3 for all principals in the account that are authorized to use Amazon S3",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:DescribeKey"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "kms:CallerAccount": {
+                        "Ref": "AWS::AccountId"
+                    },
+                    "kms:ViaService": {
+                        "Fn::Sub": "s3.${AWS::Region}.amazonaws.com"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/aws/services/CloudFormation/MacrosExamples/MergeStatements/macro.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/MergeStatements/macro.yaml
@@ -1,0 +1,183 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >
+  This CloudFormation template is to provision the CloudFormation macro that merges IAM policy statements.
+  1. Lambda Execution role is created, if not provided
+  2. Lambda is created that implements the macro logic.
+  3. Macro is created that uses the Lambda
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    #Define user friendly Parameter Groups
+    ParameterGroups:
+      - Label:
+          default: "Macro Configuration"
+        Parameters:
+          - pMacroLambdaExecRoleARN
+      - Label:
+          default: Project Configuration
+        Parameters:
+          - pBucketName
+          - pProject
+          - pEnv
+    #Define user friendly names for the parameters
+    ParameterLabels:
+      pMacroLambdaExecRoleARN:
+        default: Macro Lambda execution role ARN
+      pBucketName:
+        default: Amazon S3 bucket name
+      pProject:
+        default: Project name
+      pEnv:
+        default: Environment
+
+Parameters:
+  pMacroLambdaExecRoleARN:
+    Description: If empty, new Macro Lambda execution role will be created
+    Type: String
+    Default: ""
+  pBucketName:
+    Description: The bucket where statement files are available.
+    Type: String
+  pProject:
+    Description: The project name e.g. myp.
+    Type: String
+    Default: myp
+  pEnv:
+    Description: The environment identifier e.g. dev
+    Type: String
+    Default: dev
+
+Conditions:
+  cCreateMacroLambdaExecRole: !Equals
+    - !Ref pMacroLambdaExecRoleARN
+    - ""
+
+Resources:
+  rMacroLambdaExecRole:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: "Role Name is used for identification, it is OK to replace"
+          - id: W11
+            reason: "Only 'Describe*' is allowed"
+    Type: AWS::IAM::Role
+    Condition: cCreateMacroLambdaExecRole
+    Properties:
+      RoleName: !Sub cfn-macro-merge-sids-exec-role-${pProject}-${pEnv}
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: "/"
+      #PermissionsBoundary: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/Permission_Boundary_if_any
+      Policies:
+        - PolicyName: lambda-cw-access
+          PolicyDocument:
+            Statement:
+              - Sid: LambdaAccessForCWLogGroup
+                Effect: Allow
+                Action: logs:CreateLogGroup
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
+              - Sid: LambdaAccessForCWLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*
+        - PolicyName: lambda-s3-access
+          PolicyDocument:
+            Statement:
+              - Sid: ListObjectsInBucket
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:s3:::${pBucketName}"
+              - Sid: AllObjectActions
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:s3:::${pBucketName}/*"
+      Tags:
+        - Key: Project
+          Value: !Ref pProject
+        - Key: Env
+          Value: !Ref pEnv
+        - Key: CreatedBy
+          Value: !Ref AWS::StackId
+
+  rMergeSidsFunction:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: "VPC Access not required"
+          - id: W58
+            reason: "Permission to write CloudWatch logs provided via execution role in security template"
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Description: "Merge IAM policy statements"
+      FunctionName: !Sub cfn-macro-merge-sids-${pProject}-${pEnv}
+      Handler: index.handler
+      Role: !If
+        - cCreateMacroLambdaExecRole
+        - !GetAtt "rMacroLambdaExecRole.Arn"
+        - !Ref pMacroLambdaExecRoleARN
+      Timeout: 300
+      Runtime: python3.9
+      ReservedConcurrentExecutions: 2
+      Code:
+        ZipFile: !Sub |
+          import json
+          import boto3
+
+          s3 = boto3.client('s3')
+
+          def handler(event, context):
+              print( json.dumps(event, indent=2))
+
+              response = {
+                  "requestId": event["requestId"],
+                  "status": "success"
+              }
+
+              response["fragment"] = []
+
+              params = event["params"]
+              templateParams = event["templateParameterValues"]
+
+              try:
+                  files = params.pop("Files")
+                  file_keys = files.split(',')
+                  for file_key in file_keys :
+                    s3Object = s3.get_object(Bucket="${pBucketName}", Key=file_key)
+                    strContent = s3Object['Body'].read().decode("utf-8")
+                    stmt = json.loads(strContent)
+                    for sid in stmt["Statement"] :
+                      response["fragment"].append( sid )
+              except Exception as e:
+                  print( f"Error:{str(e)}" )
+
+              # print( json.dumps(response, indent=2))
+              return response
+      Tags:
+        - Key: Project
+          Value: !Ref pProject
+        - Key: Env
+          Value: !Ref pEnv
+        - Key: CreatedBy
+          Value: !Ref AWS::StackId
+  mMergeStatements:
+    Type: AWS::CloudFormation::Macro
+    Properties:
+      Name: MergeStatements
+      Description: Merge IAM policy statements from json files
+      FunctionName: !GetAtt rMergeSidsFunction.Arn

--- a/aws/services/CloudFormation/MacrosExamples/MergeStatements/params.json
+++ b/aws/services/CloudFormation/MacrosExamples/MergeStatements/params.json
@@ -1,0 +1,18 @@
+[
+    {
+        "ParameterKey": "pBucketName",
+        "ParameterValue": "<your-template-bucket>"
+    },
+    {
+        "ParameterKey": "pKMSAdminRoles",
+        "ParameterValue": "<comma-delimited-list-of-admin-role-arns>"
+    },
+    {
+        "ParameterKey": "pProject",
+        "ParameterValue": "myp"
+    },
+    {
+        "ParameterKey": "pEnv",
+        "ParameterValue": "dev"
+    }
+]

--- a/aws/services/CloudFormation/MacrosExamples/MergeTags/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/MergeTags/README.md
@@ -1,0 +1,243 @@
+# AWS CloudFormation Macro to merge local tags with common tags
+AWS cloud resources support [tagging](https://docs.aws.amazon.com/tag-editor/latest/userguide/tagging.html) to identify, organize, search for, and filter resources. Tags are used to categorize resources by purpose, ownership, environment, or other criteria like costing.
+
+A well organized solution involving AWS resources should define a tagging strategy that includes static tags, parameterized tags and local tags. This results into a long list of tags that must be defined for each resource. For example:
+```yaml
+# ...
+Resources:
+  rCustomerDataBucket:
+    Type: AWS::S3::Bucket
+    # ...
+    Properties:
+      AccessControl: Private
+      # ...
+      Tags:
+        - Key: Project
+          Value: !Ref pProject
+        - Key: Env
+          Value: !Ref pEnv
+        - Key: CreatedBy
+          Value: !Ref AWS::StackId
+        - Key: Team
+          Value: my-team
+        - Key: Owner
+          Value: my-team@example.com
+        - Key: Org
+          Value: my-org
+        - Key: CostCenter
+          Value: 99999
+        - Key: Purpose
+          Value: customer-data
+        - Key: Confidentiality
+          Value: L3
+# ...
+```
+Any change in the tagging strategy may impact many AWS CloudFormation templates and AWS resources.
+
+This Macro can be used to merge local tags with common static and parameterized tags, resulting in concise and manageable templates.
+
+The macro can be used via `Fn::Transform`. For example:
+```yaml
+# ...
+Resources:
+  rCustomerDataBucket:
+    Type: AWS::S3::Bucket
+    # ...
+    Properties:
+      AccessControl: Private
+      # ...
+      Tags:
+        Fn::Transform:
+          Name: MergeTags
+          Parameters:
+            TagsFile: !Sub templates/${pEnv}/tags.json
+            Purpose: customer-data
+            Confidentiality: L3
+# ...
+```
+Here, the `TagsFile` parameter points to a `json` file that defines common static and parameterized tags. For example:
+```json
+{
+  "Tags": [
+    {
+      "Key": "Project",
+      "Value": {
+        "Ref": "pProject"
+      }
+    },
+    {
+      "Key": "Env",
+      "Value": {
+        "Ref": "pEnv"
+      }
+    },
+    {
+      "Key": "CreatedBy",
+      "Value": {
+        "Ref": "AWS::StackId"
+      }
+    },
+    {
+      "Key": "Team",
+      "Value": "my-team"
+    },
+    {
+      "Key": "Owner",
+      "Value": "my-team@example.com"
+    },
+    {
+      "Key": "Org",
+      "Value": "my-org"
+    },
+    {
+      "Key": "CostCenter",
+      "Value": "99999"
+    }
+  ]
+}
+```
+
+<div style="page-break-after: always;"></div>
+
+## Deployment
+- Provide the parameters, as per your environment, in `params.json` parameter file. Provide the name of an existing bucket in `pBucketName`.
+  ```json
+  [
+    {
+      "ParameterKey": "pBucketName",
+      "ParameterValue": "<your-template-bucket>"
+    },
+    {
+      "ParameterKey": "pProject",
+      "ParameterValue": "myp"
+    },
+    {
+      "ParameterKey": "pEnv",
+      "ParameterValue": "dev"
+    }
+  ]
+  ```
+- Deploy the `macro.yaml` template to a CloudFormation stack e.g. "myp-dev-MergeTags-macro"
+  ```bash
+  aws cloudformation deploy --stack-name myp-dev-MergeTags-macro --template-file ./macro.yaml --parameter-overrides file://params.json --capabilities CAPABILITY_NAMED_IAM
+  ```
+- Copy the sample common tag file `tags.json` to bucket. For example:
+  ```bash
+  aws s3 cp tags.json s3://${pBucketName}/templates/${pEnv}/tags.json
+  ```
+- Deploy the `example.yaml` template to a CloudFormation stack e.g. "myp-dev-MergeTags-example".
+  ```bash
+  aws cloudformation deploy --stack-name myp-dev-MergeTags-example --template-file ./example.yaml --parameter-overrides file://params.json
+  ```
+- Verify the merged static, parameterized and local tags for the newly created sample bucket
+  ```bash
+  aws s3api get-bucket-tagging --bucket ${SampleBucketName}
+  {
+    "TagSet": [
+      {
+        "Key": "Project",
+        "Value": "myp"
+      },
+      {
+        "Key": "Env",
+        "Value": "dev"
+      },
+      {
+        "Key": "CreatedBy",
+        "Value": "<stack-arn>"
+      },
+      {
+        "Key": "Team",
+        "Value": "my-team"
+      },
+      {
+        "Key": "Owner",
+        "Value": "my-team@example.com"
+      },
+      {
+        "Key": "Org",
+        "Value": "my-org"
+      },
+      {
+        "Key": "CostCenter",
+        "Value": "99999"
+      },
+      {
+        "Key": "Purpose",
+        "Value": "customer-data"
+      },
+      {
+        "Key": "Confidentiality",
+        "Value": "L3"
+      }
+    ]
+  }
+  ```
+## Cleanup
+- Delete the "myp-dev-MergeTags-example" stack.
+  ```bash
+  aws cloudformation delete-stack --stack-name myp-dev-MergeTags-example
+  ```
+- Delete the "myp-dev-MergeTags-macro" stack.
+  ```bash
+  aws cloudformation delete-stack --stack-name myp-dev-MergeTags-macro
+  ```
+
+## Usage
+- Use the macro via the `Fn::Transform` function for any AWS CloudFormation resource that supports [Tags](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html) property. For example:
+  ```yaml
+  # ...
+  Tags:
+    Fn::Transform:
+      Name: MergeTags
+      Parameters:
+        TagsFile: !Sub templates/${pEnv}/tags.json
+  # ...
+  ```
+- `TagsFile` parameter is the only mandatory parameter. It points to a `json` file that defines common tags.
+  - Tags in the `json` file may be static. For example:
+    ```json
+    {
+      "Tags": [
+        {
+          "Key": "CostCenter",
+          "Value": "99999"
+        }
+      ]
+    }
+    ```
+  - Tags in the `json` file may also be parameterized, using the intrinsic function [Ref](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html). For example:
+    ```json
+    {
+      "Tags": [
+        {
+          "Key": "Env",
+          "Value": {
+            "Ref": "pEnv"
+          }
+        },
+        {
+          "Key": "CreatedBy",
+          "Value": {
+            "Ref": "AWS::StackId"
+          }
+        }
+      ]
+    }
+    ```
+- Resource specific local tags can be specified via additional `TagKey: TagValue` parameters. For example:
+  ```yaml
+  # ...
+  Tags:
+    Fn::Transform:
+      Name: MergeTags
+      Parameters:
+        TagsFile: !Sub templates/${pEnv}/tags.json
+        Purpose: customer-data
+        Confidentiality: L3
+  # ...
+  ```
+## Authors
+
+[Vivek Goyal](https://github.com/vivgoyal-aws) AWS ProServ Sr. Cloud Infrastructure Architect
+

--- a/aws/services/CloudFormation/MacrosExamples/MergeTags/example.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/MergeTags/example.yaml
@@ -1,0 +1,97 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >
+  This CloudFormation template for testing macro
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    #Define user friendly Parameter Groups
+    ParameterGroups:
+      - Label:
+          default: Project Configuration
+        Parameters:
+          - pProject
+          - pEnv
+    #Define user friendly names for the parameters
+    ParameterLabels:
+      pProject:
+        default: Project name
+      pEnv:
+        default: Environment
+
+Parameters:
+  pProject:
+    Description: The project name e.g. myp.
+    Type: String
+    Default: myp
+  pEnv:
+    Description: The environment identifier e.g. DEV
+    Type: String
+    Default: dev
+
+Resources:
+  rCustomerDataBucket:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W35
+            reason: "sample"
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002 #Fn:transform is used
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      BucketName: !Sub "${pProject}-${pEnv}-customer-data-${AWS::AccountId}-${AWS::Region}"
+      AccessControl: Private
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: true
+      PublicAccessBlockConfiguration:
+        RestrictPublicBuckets: true
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+      Tags:
+        Fn::Transform:
+          Name: MergeTags
+          Parameters:
+            TagsFile: !Sub templates/${pEnv}/tags.json
+            Purpose: customer-data
+            Confidentiality: L3
+  rCustomerDataBucketPolicy:
+    Type: "AWS::S3::BucketPolicy"
+    Properties:
+      Bucket:
+        Ref: rCustomerDataBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ForceSSLOnlyAccess
+            Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:s3:::${rCustomerDataBucket}"
+              - !Sub "arn:${AWS::Partition}:s3:::${rCustomerDataBucket}/*"
+            Condition:
+              Bool:
+                aws:SecureTransport: "false"
+          - Sid: EnforceTLSv12orHigher
+            Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:s3:::${rCustomerDataBucket}"
+              - !Sub "arn:${AWS::Partition}:s3:::${rCustomerDataBucket}/*"
+            Condition:
+              NumericLessThan:
+                s3:TlsVersion: 1.2

--- a/aws/services/CloudFormation/MacrosExamples/MergeTags/macro.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/MergeTags/macro.yaml
@@ -1,0 +1,197 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >
+  This CloudFormation template is to provision the CloudFormation macro that merges local tags with common tags.
+  1. Lambda Execution role is created, if not provided
+  2. Lambda is created that implements the macro logic.
+  3. Macro is created that uses the Lambda
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    #Define user friendly Parameter Groups
+    ParameterGroups:
+      - Label:
+          default: "Macro Configuration"
+        Parameters:
+          - pMacroLambdaExecRoleARN
+      - Label:
+          default: Project Configuration
+        Parameters:
+          - pBucketName
+          - pProject
+          - pEnv
+    #Define user friendly names for the parameters
+    ParameterLabels:
+      pMacroLambdaExecRoleARN:
+        default: Macro Lambda execution role ARN
+      pBucketName:
+        default: Amazon S3 bucket name
+      pProject:
+        default: Project name
+      pEnv:
+        default: Environment
+
+Parameters:
+  pMacroLambdaExecRoleARN:
+    Description: If empty, new Macro Lambda execution role will be created
+    Type: String
+    Default: ""
+  pBucketName:
+    Description: The bucket where common tag file(s) are available.
+    Type: String
+  pProject:
+    Description: The project name e.g. myp.
+    Type: String
+    Default: myp
+  pEnv:
+    Description: The environment identifier e.g. dev
+    Type: String
+    Default: dev
+
+Conditions:
+  cCreateMacroLambdaExecRole: !Equals
+    - !Ref pMacroLambdaExecRoleARN
+    - ""
+
+Resources:
+  rMacroLambdaExecRole:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: "Role Name is used for identification, it is OK to replace"
+          - id: W11
+            reason: "Only 'Describe*' is allowed"
+    Type: AWS::IAM::Role
+    Condition: cCreateMacroLambdaExecRole
+    Properties:
+      RoleName: !Sub cfn-macro-merge-tags-exec-role-${pProject}-${pEnv}
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: "/"
+      #PermissionsBoundary: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/Permission_Boundary_if_any
+      Policies:
+        - PolicyName: lambda-cw-access
+          PolicyDocument:
+            Statement:
+              - Sid: LambdaAccessForCWLogGroup
+                Effect: Allow
+                Action: logs:CreateLogGroup
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
+              - Sid: LambdaAccessForCWLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*
+        - PolicyName: lambda-s3-access
+          PolicyDocument:
+            Statement:
+              - Sid: ListObjectsInBucket
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:s3:::${pBucketName}"
+              - Sid: AllObjectActions
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:s3:::${pBucketName}/*"
+      Tags:
+        - Key: Project
+          Value: !Ref pProject
+        - Key: Env
+          Value: !Ref pEnv
+        - Key: CreatedBy
+          Value: !Ref AWS::StackId
+
+  rMergeTagsFunction:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: "VPC Access not required"
+          - id: W58
+            reason: "Permission to write CloudWatch logs provided via execution role in security template"
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Description: "Merge local tags with common tags in a JSON file"
+      FunctionName: !Sub cfn-macro-merge-tags-${pProject}-${pEnv}
+      Handler: index.handler
+      Role: !If
+        - cCreateMacroLambdaExecRole
+        - !GetAtt "rMacroLambdaExecRole.Arn"
+        - !Ref pMacroLambdaExecRoleARN
+      Timeout: 300
+      Runtime: python3.9
+      ReservedConcurrentExecutions: 2
+      Code:
+        ZipFile: !Sub |
+          import json
+          import boto3
+
+          s3 = boto3.client('s3')
+
+          def handler(event, context):
+              print( json.dumps(event, indent=2))
+
+              response = {
+                  "requestId": event["requestId"],
+                  "status": "success"
+              }
+
+              response["fragment"] = []
+              params = event["params"]
+              templateParams = event["templateParameterValues"]
+
+              tags = {
+                  "Tags" : []
+              }
+
+              try:
+                  tagsFile = params.pop("TagsFile")
+                  pEnv = templateParams["pEnv"]
+                  s3Object = s3.get_object(Bucket="${pBucketName}", Key=tagsFile)
+                  strContent = s3Object['Body'].read().decode("utf-8")
+                  tags = json.loads(strContent)
+              except Exception as e:
+                  print( str(e) )
+
+              # print( json.dumps(tags, indent=2))
+
+              for tag in tags["Tags"] :
+                  response["fragment"].append( tag )
+
+              for k in params :
+                  response["fragment"].append(
+                      {
+                          "Key": k,
+                          "Value": params[k]
+                      }
+                  )
+
+              # print( json.dumps(response, indent=2))
+              return response
+      Tags:
+        - Key: Project
+          Value: !Ref pProject
+        - Key: Env
+          Value: !Ref pEnv
+        - Key: CreatedBy
+          Value: !Ref AWS::StackId
+
+  mMergeTags:
+    Type: AWS::CloudFormation::Macro
+    Properties:
+      Name: MergeTags
+      Description: Merge local tags with common tags
+      FunctionName: !GetAtt rMergeTagsFunction.Arn

--- a/aws/services/CloudFormation/MacrosExamples/MergeTags/params.json
+++ b/aws/services/CloudFormation/MacrosExamples/MergeTags/params.json
@@ -1,0 +1,14 @@
+[
+    {
+        "ParameterKey": "pBucketName",
+        "ParameterValue": "<your-template-bucket>"
+    },
+    {
+        "ParameterKey": "pProject",
+        "ParameterValue": "myp"
+    },
+    {
+        "ParameterKey": "pEnv",
+        "ParameterValue": "dev"
+    }
+]

--- a/aws/services/CloudFormation/MacrosExamples/MergeTags/tags.json
+++ b/aws/services/CloudFormation/MacrosExamples/MergeTags/tags.json
@@ -1,0 +1,38 @@
+{
+    "Tags": [
+        {
+            "Key": "Project",
+            "Value": {
+                "Ref": "pProject"
+            }
+        },
+        {
+            "Key": "Env",
+            "Value": {
+                "Ref": "pEnv"
+            }
+        },
+        {
+            "Key": "CreatedBy",
+            "Value": {
+                "Ref": "AWS::StackId"
+            }
+        },
+        {
+            "Key": "Team",
+            "Value": "my-team"
+        },
+        {
+            "Key": "Owner",
+            "Value": "my-team@example.com"
+        },
+        {
+            "Key": "Org",
+            "Value": "my-org"
+        },
+        {
+            "Key": "CostCenter",
+            "Value": "99999"
+        }
+    ]
+}


### PR DESCRIPTION
*Issue #, if available:*

MergeStatements macro can be used to merge IAM policy statements from JSON files
MergeTags macro can be used to merge common/parameterized tags from a JSON file with local tags


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
