### PR TITLE
Fix example code and other minor code style and document updates

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/ExpandStack/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/ExpandStack/README.md
@@ -75,7 +75,9 @@ Resources:
   ```bash
   aws cloudformation deploy --stack-name myp-dev-ExpandStack-macro --template-file ./macro.yaml --capabilities CAPABILITY_NAMED_IAM
   ```
-- Provide the parameters, as per your environment, in `params.json` parameter file. Provide the name of an existing bucket in `pTemplateBucket`.
+- Resource type `AWS::CloudFormation::Stack` requires the stack template(s) be available on an Amazon S3 bucket (e.g. `pTemplateBucket`).
+  - If you don't have one already, create one with `aws s3 mb s3://${pTemplateBucket}`
+- Provide the parameters, as per your environment, in `params.json` parameter file. Provide the name of an existing bucket for templates in `pTemplateBucket`.
   ```json
   [
     {
@@ -92,11 +94,11 @@ Resources:
     }
   ]
   ```
-- Copy the sample `ecr-repo.yaml` template to bucket. For example:
+- Copy the sample `ecr-repo.yaml` template to `pTemplateBucket` bucket. For example:
   ```bash
   aws s3 cp ecr-repo.yaml s3://${pTemplateBucket}/templates/${pEnv}/ecr/ecr-repo.yaml
   ```
-- Copy the sample `s3-bucket.yaml` template to bucket. For example:
+- Copy the sample `s3-bucket.yaml` template to `pTemplateBucket` bucket. For example:
   ```bash
   aws s3 cp s3-bucket.yaml s3://${pTemplateBucket}/templates/${pEnv}/s3/s3-bucket.yaml
   ```

--- a/aws/services/CloudFormation/MacrosExamples/ExpandStack/ecr-repo.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/ExpandStack/ecr-repo.yaml
@@ -2,14 +2,14 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
 Description: >
-  This CloudFormation template is meant to be used as nested stack to create a private repository
+  This CloudFormation template is meant to be used as nested stack to create a private ECR repository.
 
 Metadata:
   AWS::CloudFormation::Interface:
     #Define user friendly Parameter Groups
     ParameterGroups:
       - Label:
-          default: "Private Repository Configuration"
+          default: Private Repository Configuration
         Parameters:
           - pNamespace
           - pRepoName
@@ -40,6 +40,8 @@ Parameters:
     Description: The private repository name.
     Type: String
     Default: hello-world
+    MinLength: 3
+    MaxLength: 239 #${pNamespace)/${pRepoName} max allowed is 256
   pProject:
     Description: The project name e.g. myp.
     Type: String
@@ -55,9 +57,9 @@ Resources:
       cfn_nag:
         rules_to_suppress:
           - id: W28
-            reason: "Application requires explicit name for the repository."
+            reason: Application requires explicit name for the repository.
           - id: W79
-            reason: "Scanning will be enabled at the registry level."
+            reason: Scanning will be enabled at the registry level.
     Type: AWS::ECR::Repository
     Properties:
       RepositoryName: !Sub "${pNamespace}/${pRepoName}"

--- a/aws/services/CloudFormation/MacrosExamples/ExpandStack/example.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/ExpandStack/example.yaml
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: ExpandStack1
+Transform: ExpandStack
 
 Description: >
   This CloudFormation template for testing macro

--- a/aws/services/CloudFormation/MacrosExamples/ExpandStack/macro.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/ExpandStack/macro.yaml
@@ -39,9 +39,9 @@ Resources:
       cfn_nag:
         rules_to_suppress:
           - id: W28
-            reason: "Role Name is used for identification, it is OK to replace"
+            reason: Role Name is used for identification, it is OK to replace
           - id: W11
-            reason: "Only 'Describe*' is allowed"
+            reason: Only Describe* is allowed
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Sub cfn-macro-expand-stack-exec-role-${pProject}-${pEnv}
@@ -82,12 +82,12 @@ Resources:
       cfn_nag:
         rules_to_suppress:
           - id: W89
-            reason: "VPC Access not required"
+            reason: VPC Access not required
           - id: W58
-            reason: "Permission to write CloudWatch logs provided via execution role in security template"
-    Type: "AWS::Lambda::Function"
+            reason: Permission to write CloudWatch logs provided via execution role in security template
+    Type: AWS::Lambda::Function
     Properties:
-      Description: "Expand a Resource of Type AWS::CloudFormation::Stack"
+      Description: Expand a Resource of Type AWS::CloudFormation::Stack
       FunctionName: !Sub cfn-macro-expand-stack-${pProject}-${pEnv}
       Handler: index.handler
       Role: !GetAtt "rMacroLambdaExecRole.Arn"

--- a/aws/services/CloudFormation/MacrosExamples/ExpandStack/s3-bucket.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/ExpandStack/s3-bucket.yaml
@@ -2,14 +2,14 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
 Description: >
-  his CloudFormation template is meant to be used as nested stack to create a S3 bucket.
+  This CloudFormation template is meant to be used as nested stack to create a S3 bucket.
 
 Metadata:
   AWS::CloudFormation::Interface:
     #Define user friendly Parameter Groups
     ParameterGroups:
       - Label:
-          default: "Storage Configuration"
+          default: Storage Configuration
         Parameters:
           - pBucketName
       - Label:
@@ -46,7 +46,7 @@ Resources:
       cfn_nag:
         rules_to_suppress:
           - id: W35
-            reason: "sample"
+            reason: sample
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
@@ -74,7 +74,7 @@ Resources:
         - Key: CreatedBy
           Value: !Ref AWS::StackId
   rPvtBucketPolicy:
-    Type: "AWS::S3::BucketPolicy"
+    Type: AWS::S3::BucketPolicy
     Properties:
       Bucket:
         Ref: rPvtBucket


### PR DESCRIPTION
Fixed example, it was using a wrong Macro name
Modified documentation, added clarity on the template bucket
Modified code to be use quotes consistently
