### PR TITLE
Update cfnresponse.py to feature a reason parameter

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/StackMetrics/lambda/cfnresponse.py
+++ b/aws/services/CloudFormation/MacrosExamples/StackMetrics/lambda/cfnresponse.py
@@ -7,14 +7,14 @@ http = urllib3.PoolManager()
 SUCCESS = "SUCCESS"
 FAILED = "FAILED"
 
-def send(event, context, responseStatus, responseData, physicalResourceId=None, noEcho=False):
+def send(event, context, responseStatus, responseData, physicalResourceId=None, noEcho=False, reason=None):
     responseUrl = event['ResponseURL']
 
     print(responseUrl)
 
     responseBody = {}
     responseBody['Status'] = responseStatus
-    responseBody['Reason'] = 'See the details in CloudWatch Log Stream: ' + context.log_stream_name
+    responseBody['Reason'] = reason or 'See the details in CloudWatch Log Stream: ' + context.log_stream_name
     responseBody['PhysicalResourceId'] = physicalResourceId or context.log_stream_name
     responseBody['StackId'] = event['StackId']
     responseBody['RequestId'] = event['RequestId']
@@ -32,7 +32,7 @@ def send(event, context, responseStatus, responseData, physicalResourceId=None, 
     }
 
     try:
-        
+
         response = http.request('PUT',responseUrl,body=json_responseBody.encode('utf-8'),headers=headers)
         print("Status code: " + response.reason)
     except Exception as e:


### PR DESCRIPTION
Add a "reason" parameter to the send() function. This parameter is in the sample python module featured in the official documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-lambda-function-code-cfnresponsemodule.html but is not present here.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
