### PR TITLE
ServiceCatalog - Change default parameters

### DIFF
--- a/aws/services/ServiceCatalog/Product.yaml
+++ b/aws/services/ServiceCatalog/Product.yaml
@@ -15,16 +15,16 @@
 # * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # */
 
-AWSTemplateFormatVersion: '2010-09-09'
-Description: 'CI/CD optimized AWS CloudFormation Sample Template for AWS Service Catalog Product creation.
-             ### Before deployment please make sure that all parameters are reviewed and updated according the specific use case. ###
-             **WARNING**
-             This template creates AWS Service Catalog Product, please make sure you review billing costs for AWS Service Catalog.'
+AWSTemplateFormatVersion: "2010-09-09"
+Description:
+  "CI/CD optimized AWS CloudFormation Sample Template for AWS Service Catalog Product creation.
+  ### Before deployment please make sure that all parameters are reviewed and updated according the specific use case. ###
+  **WARNING**
+  This template creates AWS Service Catalog Product, please make sure you review billing costs for AWS Service Catalog."
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-      -
-        Label:
+      - Label:
           default: "Service Catalog Product Tags"
         Parameters:
           - AppName
@@ -32,13 +32,11 @@ Metadata:
           - Dept
           - User
           - Owner
-      -
-        Label:
+      - Label:
           default: "Service Catalog Portfolio Stack Name"
         Parameters:
           - ServiceCatalogPortfolioStackName
-      -
-        Label:
+      - Label:
           default: "Service Catalog Product Details"
         Parameters:
           - SCProductName
@@ -48,188 +46,175 @@ Metadata:
           - SCProductDistributor
           - SCSupportEmail
           - SCSupportUrl
-      -
-        Label:
+      - Label:
           default: "Service Catalog Portfolio Display Name"
         Parameters:
           - PortfolioDisplayName
-      -
-        Label:
+      - Label:
           default: "Service Catalog Product Details"
         Parameters:
-          - S3Bucket
+          - ProvisioningArtifactTemplateUrl
           - ProvisioningArtifactNameParameter
           - ProvisioningArtifactDescriptionParameter
 
 Parameters:
-
-# Enviornment type
+  # Enviornment type
   Env:
-    Description:    Please specify the target Environment. Used for tagging and resource names. Mandatory LOWER CASE.
-    Type:           String
-    Default:        "dev"
+    Description: Please specify the target Environment. Used for tagging and resource names. Mandatory LOWER CASE.
+    Type: String
+    Default: "dev"
     AllowedValues:
       - test
       - dev
       - prod
 
-# Application Name
+  # Application Name
   AppName:
-    Description:    Please specify the Application Name. Used for tagging and resource names. Mandatory LOWER CASE.
-    Type:           String
-    Default:        "app"
+    Description: Please specify the Application Name. Used for tagging and resource names. Mandatory LOWER CASE.
+    Type: String
+    Default: "app"
 
-# Department
+  # Department
   Dept:
-    Description:    Please specify the Department. Used for tagging
-    Type:           String
-    Default:        "1234"
+    Description: Please specify the Department. Used for tagging
+    Type: String
+    Default: "1234"
 
-# User
+  # User
   User:
-    Description:    Please specify the User. Used for tagging
-    Type:           String
-    Default:        "User"
+    Description: Please specify the User. Used for tagging
+    Type: String
+    Default: "User"
 
-# Owner
+  # Owner
   Owner:
-    Description:    Please specify the Owner. Used for tagging
-    Type:           String
-    Default:        "Owner"
+    Description: Please specify the Owner. Used for tagging
+    Type: String
+    Default: "Owner"
 
-# Service Catalog Portfolio Stack Name
+  # Service Catalog Portfolio Stack Name
   ServiceCatalogPortfolioStackName:
-    Description:    Please specify the Service Catalog Portfolio Stack Name.
-    Type:           String
-    Default:        ""
+    Description: Please specify the Service Catalog Portfolio Stack Name.
+    Type: String
+    Default: ""
 
-# ServiceCatalog Product Name
+  # ServiceCatalog Product Name
   SCProductName:
-    Description:    Please specify ServiceCatalog Product Name.
-    Type:           String
-    Default:        "ProductName"
+    Description: Please specify ServiceCatalog Product Name.
+    Type: String
+    Default: "ProductName"
 
-# ServiceCatalog Product Name Description
+  # ServiceCatalog Product Name Description
   SCProductDescription:
-    Description:    Please specify ServiceCatalog Product Name Description.
-    Type:           String
-    Default:        "ProductDescription"
+    Description: Please specify ServiceCatalog Product Name Description.
+    Type: String
+    Default: "ProductDescription"
 
-# ServiceCatalog Product Name Owner
+  # ServiceCatalog Product Name Owner
   SCProductOwner:
-    Description:    Please specify ServiceCatalog Product Owner.
-    Type:           String
-    Default:        "ProductOwner"
+    Description: Please specify ServiceCatalog Product Owner.
+    Type: String
+    Default: "ProductOwner"
 
-# ServiceCatalog Product Support
+  # ServiceCatalog Product Support
   SCProductSupport:
-    Description:    Please specify ServiceCatalog Product Support.
-    Type:           String
-    Default:        "IT Support can be reached @support"
+    Description: Please specify ServiceCatalog Product Support.
+    Type: String
+    Default: "IT Support can be reached @support"
 
-# ServiceCatalog Product Distributor
+  # ServiceCatalog Product Distributor
   SCProductDistributor:
-    Description:    Please specify ServiceCatalog Product Distributor.
-    Type:           String
-    Default:        "App Vendor"
+    Description: Please specify ServiceCatalog Product Distributor.
+    Type: String
+    Default: "App Vendor"
 
-# ServiceCatalog Product Support Email
+  # ServiceCatalog Product Support Email
   SCSupportEmail:
-    Description:    Please specify ServiceCatalog Product Support Email.
-    Type:           String
-    Default:        "support@example.com"
+    Description: Please specify ServiceCatalog Product Support Email.
+    Type: String
+    Default: "support@example.com"
 
-# ServiceCatalog Product Support URL
+  # ServiceCatalog Product Support URL
   SCSupportUrl:
-    Description:    Please specify ServiceCatalog Product Support URL.
-    Type:           String
-    Default:        "http://www.support.example.com"
+    Description: Please specify ServiceCatalog Product Support URL.
+    Type: String
+    Default: "https://www.support.example.com"
 
-# ServiceCatalog Product S3 Bucket
-  S3Bucket:
-    Description:    Please specify ServiceCatalog Product S3 Bucket.
-    Type:           String
-    Default:        "mytestbucket"
+  # ServiceCatalog Product S3 Bucket
+  ProvisioningArtifactTemplateUrl:
+    Description: Please specify the S3 URL of the template
+    Type: String
+    Default: "https://awsdocs.s3.amazonaws.com/servicecatalog/development-environment.template"
 
-# ServiceCatalog Product Artifact Name
-  ProductArtifactName:
-    Description:    Please specify ServiceCatalog Product Artifact Name.
-    Type:           String
-    Default:        "productexample.yaml"
-
-# ServiceCatalog Product Artifact Name
+  # ServiceCatalog Product Artifact Name
   ProvisioningArtifactNameParameter:
-    Description:    Please specify ServiceCatalog Product Artifact Name.
-    Type:           String
-    Default:        "ProductExample"
+    Description: Please specify ServiceCatalog Product Artifact Name.
+    Type: String
+    Default: "ProductExample"
 
-# ServiceCatalog Product Artifact Description
+  # ServiceCatalog Product Artifact Description
   ProvisioningArtifactDescriptionParameter:
-    Description:    Please specify ServiceCatalog Product Artifact Description.
-    Type:           String
-    Default:        "ProductExample"
+    Description: Please specify ServiceCatalog Product Artifact Description.
+    Type: String
+    Default: "ProductExample"
 
 Resources:
-
   ServiceCatalogCloudFormationProduct:
     Type: "AWS::ServiceCatalog::CloudFormationProduct"
     Properties:
-      Name: !Ref 'SCProductName'
-      Description: !Ref 'SCProductDescription'
-      Owner: !Ref 'SCProductOwner'
-      SupportDescription: !Ref 'SCProductSupport'
-      Distributor:  !Ref 'SCProductDistributor'
-      SupportEmail:  !Ref 'SCSupportEmail'
-      SupportUrl: !Sub '${SCSupportUrl}'
+      Name: !Ref "SCProductName"
+      Description: !Ref "SCProductDescription"
+      Owner: !Ref "SCProductOwner"
+      SupportDescription: !Ref "SCProductSupport"
+      Distributor: !Ref "SCProductDistributor"
+      SupportEmail: !Ref "SCSupportEmail"
+      SupportUrl: !Sub "${SCSupportUrl}"
       Tags:
-        - Key:    Name
-          Value:  !Sub '${AppName}'
-        - Key:    App
-          Value:  !Sub '${AppName}'
-        - Key:    Dept
-          Value:  !Sub '${Dept}'
-        - Key:    Env
-          Value:  !Sub '${Env}'
-        - Key:    User
-          Value:  !Sub '${User}'
-        - Key:    Owner
-          Value:  !Sub '${Owner}'
+        - Key: Name
+          Value: !Sub "${AppName}"
+        - Key: App
+          Value: !Sub "${AppName}"
+        - Key: Dept
+          Value: !Sub "${Dept}"
+        - Key: Env
+          Value: !Sub "${Env}"
+        - Key: User
+          Value: !Sub "${User}"
+        - Key: Owner
+          Value: !Sub "${Owner}"
       ProvisioningArtifactParameters:
-        -
-          Name: !Sub '${ProvisioningArtifactNameParameter}'
-          Description: !Sub '${ProvisioningArtifactDescriptionParameter}'
+        - Name: !Sub "${ProvisioningArtifactNameParameter}"
+          Description: !Sub "${ProvisioningArtifactDescriptionParameter}"
           Info:
-            LoadTemplateFromURL: !Sub "https://s3-${AWS::Region}.amazonaws.com/${S3Bucket}/${ProductArtifactName}"
+            LoadTemplateFromURL: !Sub "${ProvisioningArtifactTemplateUrl}"
 
   ServiceCatalogPortfolioProductAssociation:
     Type: "AWS::ServiceCatalog::PortfolioProductAssociation"
     DependsOn: ServiceCatalogCloudFormationProduct
     Properties:
       PortfolioId:
-          Fn::ImportValue: !Sub '${ServiceCatalogPortfolioStackName}-ServiceCatalogPortfolio'
-      ProductId: !Ref 'ServiceCatalogCloudFormationProduct'
+        Fn::ImportValue: !Sub "${ServiceCatalogPortfolioStackName}-ServiceCatalogPortfolio"
+      ProductId: !Ref "ServiceCatalogCloudFormationProduct"
 
   ServiceCatalogCustomTagOptionsAssociation:
     Type: "AWS::ServiceCatalog::TagOptionAssociation"
     Properties:
       TagOptionId:
-          Fn::ImportValue: !Sub '${ServiceCatalogPortfolioStackName}-ServiceCatalogProductTagOptions'
-      ResourceId: !Ref 'ServiceCatalogCloudFormationProduct'
-
+        Fn::ImportValue: !Sub "${ServiceCatalogPortfolioStackName}-ServiceCatalogProductTagOptions"
+      ResourceId: !Ref "ServiceCatalogCloudFormationProduct"
 
 Outputs:
-
   ServiceCatalogCloudFormationProductName:
-    Value:    !GetAtt 'ServiceCatalogCloudFormationProduct.ProductName'
+    Value: !GetAtt "ServiceCatalogCloudFormationProduct.ProductName"
     Export:
-      Name:   !Sub '${AppName}-ServiceCatalogCloudFormationProductName'
+      Name: !Sub "${AppName}-ServiceCatalogCloudFormationProductName"
 
   ServiceCatalogProvisioningArtifactIds:
-    Value:    !GetAtt 'ServiceCatalogCloudFormationProduct.ProvisioningArtifactIds'
+    Value: !GetAtt "ServiceCatalogCloudFormationProduct.ProvisioningArtifactIds"
     Export:
-      Name:   !Sub '${AppName}-ServiceCatalogCloudFormationProvisioningArtifactIds'
+      Name: !Sub "${AppName}-ServiceCatalogCloudFormationProvisioningArtifactIds"
 
   ServiceCatalogProvisioningArtifactNames:
-    Value:    !GetAtt 'ServiceCatalogCloudFormationProduct.ProvisioningArtifactNames'
+    Value: !GetAtt "ServiceCatalogCloudFormationProduct.ProvisioningArtifactNames"
     Export:
-      Name:   !Sub '${AppName}-ServiceCatalogCloudFormationProvisioningArtifactNames'
+      Name: !Sub "${AppName}-ServiceCatalogCloudFormationProvisioningArtifactNames"


### PR DESCRIPTION
Deploying using the default parameters was failing due to incorrect values. Updated the parameter default values to allow deployment to succeed without providing parameter values. Auto-formatted the document

This will resolve #351 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
