### PR TITLE
Some enhancements for AWSSupplyChain PrivateLink Setup

### DIFF
--- a/aws/services/AWSSupplyChain/SapPrivateLink/README.md
+++ b/aws/services/AWSSupplyChain/SapPrivateLink/README.md
@@ -1,22 +1,29 @@
 **Overview**
 
-These cloud formation templates can be shared to customer to setup PrivateLink infrastructures to connect to customer's SAP server
+These CloudFormation templates can automatically setup PrivateLink infrastructures securely connecting to SAP server.
 
 **Pre-requisites**
-- Customer already set up an AWS account with VPC (including various private subnets across AZs within) that can connect to their SAP serve
+
+- You already have a working SAP Gateway server that you can connect to
+
+- You already have an AWS account with Admin permission
+
+- You already setup a VPC (with private subnets within) in the AWS account and ensure
   - Either SAP server in EC2 of that VPC
-  - Or SAP server can be reachable from that VPC
-- Customer already got a public resolvable DNS name that can be used to connect to their SAP server
+  - Or SAP server can be reachable wihin that VPC (e.g. on-premise SAP connected through [AWS Site-to-Site VPN](https://docs.aws.amazon.com/vpn/latest/s2svpn/SetUpVPNConnections.html))
+
+- You already have a public resolvable DNS name that can be used to connect to their SAP server
   - Either DNS in Route53 of same account
   - Or DNS in Route53 of another account
   - Or DNS registered outside of AWS
 
 **Use CloudFormation Templates**
 
-1. Customer log into their AWS account console with Admin role
+1. Log into AWS account console with Admin permission
 
-2. Check and choose the region of the SAP-residing/connecting VPC
-   - If you want to create a privateLink in a different region, you need to first create a new VPC (CIDR range must be outside of SAP-residing/connecting VPC's one) in the new region and setup VPC-peering with SAP-residing/connecting VPC, follow https://docs.aws.amazon.com/vpc/latest/peering/working-with-vpc-peering.html
+2. Check and choose the region of your SAP-reachable VPC
+   - PrivateLink are regional service that clients can only call through PrivateLink in the same AWS region
+   - If you want to setup PrivateLink in a different region, you need to first create a new VPC in the new region and setup [VPC Peering](https://docs.aws.amazon.com/vpc/latest/peering/working-with-vpc-peering.html) with SAP-reachable VPC (noted that the CIDR of new VPC must not overlap with current VPC's IP range)
 
 3. Go to CloudFormation console and click `Create stack`
 
@@ -28,8 +35,8 @@ These cloud formation templates can be shared to customer to setup PrivateLink i
    3. Stack creating will take a while, monitor any updates shown in `Events` tab to know if and where got failures (Stack creation will auto-rollback if anything failure and will cleanup everything it created)
    4. After stack created, click `Outputs` tab, and click each of those to monitor and confirm below things:
       - Certificate's status shows `Issued`, this should always be issued otherwise Stack creation will be stuck there waiting
-      - VPCEndpointService's DomainVerification shows `Verified` (iit may take a few minutes, just keep refresh and monitoring)
-      - TargetGroup's health check shows `Healthy` (it may take a few minutes, just keep refresh and monitoring), if not healthy it means the given IP is not able to connecting to SAP, need check why
+      - VPCEndpointService's DomainVerification shows `Verified` (it may take a few minutes, just keep refresh and monitoring)
+      - TargetGroup's health check shows `Healthy` (it may take a few minutes, just keep refresh and monitoring), if not healthy need check if you give correct port or protocol to connect to your SAP or if the EC2 security group blocks the traffic
    5. If above checks all pass, the PrivateLink infrastructure created successfully, and can just use the VPCEndpointService's service name and DNS name to connect to SAP through PrivateLink
    6. If anything fails and want to retry, can just manually delete the stack to cleanup all created resources and start over
 
@@ -37,18 +44,22 @@ These cloud formation templates can be shared to customer to setup PrivateLink i
    1. Upload `SapPrivateLinkNoHostedZone.yaml` and fill all the inputs
    2. Click Next all the way (accept all acknowledgements if asked) to create that stack
    3. Stack creating will take a while, monitor any updates shown in `Events` tab to know if and where got failures (Stack creation will auto-rollback if anything failure and will cleanup everything it created)
-   4. Stack creating will stop at certificate creating step, go to that certificate in `Certificate Manager` console, in the `Domains` section take note of `CNAME name` and `CNAME value`
-   5. Go to your DNS manager trying to add a new record with below entries:
+   4. Stack creating will stop at certificate creating step (noted that if you earlier verified the certificate with the same domain, it may auto-verify and automatically create certificate), go to that certificate in `Certificate Manager` console, in the `Domains` section take note of `CNAME name` and `CNAME value`
+   5. Go to your DNS provider (in AWS it is Route53) trying to add a new record with below entries:
       - Type: `CNAME`
-      - Record Name: the `CNAME name` of certificate (noted that CNAME should end with your DNS name, in Route53 where DNS name suffix auto-populated, you just need to enter the first string segment before `.`)
+      - Record Name: the `CNAME name` of certificate (noted that CNAME should end with your domain name, if in Route53 the domain name suffix auto-populated, you just need to enter the first string segment before `.`)
       - Record Value: the `CNAME value` of certificate
-   6. If above done correctly, the domain will get verified and certificate will show `Issued` (it can take up to a few minutes), and cloudformation creation will continue
+   6. If above done correctly, the domain will get verified and certificate will show `Issued` (it can take a few minutes), and cloudformation creation will continue
    7. After stack created, click Outputs tab and click into the VPCEndpointService URL, and take note of `Domain verification name` and `Domain verification value`
-   8. Go to your DNS manager trying to add a new record with below entries:
+   8. Go to your DNS provider (in AWS it is Route53) trying to add a new record with below entries:
       - Type: `TXT`
-      - Record Name: the `Domain verification name` ending with `.<DNS>` (in Route53 where DNS name suffix auto-populated, just need to enter the `Domain verification name`)
-      - Record Value: `Domain verification value` within double quotes (in Route53, double quotes not needed)
-   9. If above done correctly, the domain will get verified shown in VPCEndpointService (it can take up to a few minutes)
-   10. Then go back to stack Outputs tab and just check the TargetGroup's health check shows `Healthy` (it may take a few minutes, just keep refresh and monitoring), if not healthy it means the given IP is not able to connecting to SAP, need check why
+      - Record Name: the `Domain verification name` ending with `.<domain name>` (if in Route53 where domain name suffix auto-populated, just need to enter the `Domain verification name`)
+      - Record Value: `Domain verification value` within double quotes (check your DNS provider if double quotes needed or not, like in Route53, double quotes not needed as will be auto-populated)
+   9. If above done correctly, the domain will get verified shown in VPCEndpointService (it can take a few minutes)
+   10. Then go back to stack Outputs tab and just check the TargetGroup's health check shows `Healthy` (it may take a few minutes, just keep refresh and monitoring), if not healthy need check if you give correct port or protocol to connect to your SAP or if the EC2 security group blocks the traffic
    11. If health check pass, the PrivateLink infrastructure created successfully, and can just use the VPCEndpointService's service name and DNS name to connect to SAP through PrivateLink
    12. If anything fails and want to retry, can just manually delete the stack to cleanup all created resources and start over
+
+7. You can find all resources created in the CloudFormation stack's `Resources` tab (you can fine tune by directly editting resource, but it is not advised to delete those resources as they can make CloudFormation delete failing or stucking for quite long time, always delete CloudFormation stack to delete and cleanup resources)
+
+8. If CloudFormation stuck in deleting, it is very possible there are existing connections to the created VPC Endpoint Service, need to manually reject those connections and CloudFormation's deletion will resume automatically

--- a/aws/services/AWSSupplyChain/SapPrivateLink/SapPrivateLink.yaml
+++ b/aws/services/AWSSupplyChain/SapPrivateLink/SapPrivateLink.yaml
@@ -18,12 +18,14 @@ Metadata:
           default: SAP Configuration
         Parameters:
           - IP
+          - Protocol
           - Port
+          - HealthCheckPath
           - InVpc
 Parameters:
   DomainName:
     Type: String
-    Description: The Fully Qualified Domain Name (FQDN) of PrivateLink DNS
+    Description: The fully qualified or wildcard domain name of DNS
   HostedZone:
     Type: AWS::Route53::HostedZone::Id
     Description: The public hostedZone of above FQDN
@@ -36,10 +38,21 @@ Parameters:
   IP:
     Type: String
     Description: SAP Gateway's private IP address within VPC
+  Protocol:
+    Type: String
+    AllowedValues:
+      - "HTTP"
+      - "HTTPS"
+    Default: "HTTP"
+    Description: SAP Gateway's connect protocol
   Port:
     Type: Number
     Default: 50000
-    Description: SAP Gateway's HTTP/HTTPS port number
+    Description: SAP Gateway's HTTP or HTTPS (match with protocol you choose above) port number
+  HealthCheckPath:
+    Type: String
+    Default: /sap/public/ping
+    Description: SAP Gateway's ping path to do health check
   InVpc:
     Type: String
     AllowedValues:
@@ -49,6 +62,7 @@ Parameters:
     Description: Choose Yes if SAP resides in above VPC; choose No otherwise (in cases of above VPC just peers with another SAP residing VPC)
 Conditions:
   IpInVpc: !Equals [!Ref InVpc, "Yes"]
+  SapUseHttps: !Equals [!Ref Protocol, "HTTPS"]
 Rules:
   SubnetsInVPC:
     Assertions:
@@ -58,10 +72,17 @@ Rules:
             - Ref: VpcId
         AssertDescription: All subnets must in the VPC
 Resources:
+  ASCPrivateLinkCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Ref DomainName
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: !Ref DomainName
+          HostedZoneId: !Ref HostedZone
   ASCPrivateLinkLambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "ASCPrivateLinkLambdaRole-${AWS::Region}"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -73,7 +94,7 @@ Resources:
                 - lambda.amazonaws.com
       Path: "/"
       Policies:
-        - PolicyName: !Sub "ASCPrivateLinkLambdaPolicy-${AWS::Region}"
+        - PolicyName: ASCPrivateLinkLambdaPolicy
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
@@ -90,7 +111,6 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Description: Lambda function to help with private link infrastructure setup
-      FunctionName: ASCPrivateLinkLambdaFunction
       Handler: index.handler
       Role: !GetAtt ASCPrivateLinkLambdaRole.Arn
       Timeout: 900
@@ -151,14 +171,6 @@ Resources:
       DomainName: !Ref DomainName
       HostedZoneId: !Ref HostedZone
     DependsOn: ASCPrivateLinkVPCES
-  ASCPrivateLinkCertificate:
-    Type: AWS::CertificateManager::Certificate
-    Properties:
-      DomainName: !Ref DomainName
-      ValidationMethod: DNS
-      DomainValidationOptions:
-        - DomainName: !Ref DomainName
-          HostedZoneId: !Ref HostedZone
   ASCPrivateLinkNLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -172,15 +184,15 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       VpcId: !Ref VpcId
-      Protocol: TCP # use TCP and HTTP for health check as already TLS-terminated and traffic in local network
-      Port: !Ref Port
+      Protocol: !If [SapUseHttps, "TLS", "TCP"]
+      Port: 443
       TargetType: ip
       Targets:
         - AvailabilityZone: !If [IpInVpc, !Ref AWS::NoValue, "all"]
           Id: !Ref IP
           Port: !Ref Port
-      HealthCheckPath: /sap/public/ping
-      HealthCheckProtocol: HTTP
+      HealthCheckPath: !Ref HealthCheckPath
+      HealthCheckProtocol: !Ref Protocol
   ASCPrivateLinkListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:

--- a/aws/services/AWSSupplyChain/SapPrivateLink/SapPrivateLink.yaml
+++ b/aws/services/AWSSupplyChain/SapPrivateLink/SapPrivateLink.yaml
@@ -28,7 +28,7 @@ Parameters:
     Description: The fully qualified or wildcard domain name of DNS
   HostedZone:
     Type: AWS::Route53::HostedZone::Id
-    Description: The public hostedZone of above FQDN
+    Description: The public hostedZone of above domain name
   VpcId:
     Type: AWS::EC2::VPC::Id
     Description: VpcId of your existing Virtual Private Cloud (VPC) where SAP resides
@@ -145,7 +145,7 @@ Resources:
                               'Action': 'UPSERT',
                               'ResourceRecordSet': {
                                 'Type': validationRecord['Type'],
-                                'Name': '{}.{}'.format(validationRecord['Name'], domainName),
+                                'Name': '{}.{}'.format(validationRecord['Name'], domainName[2:] if domainName.startswith('*') else domainName),
                                 'ResourceRecords': [{'Value': '"{}"'.format(validationRecord['Value'])}],
                                 'TTL': 300
                               }

--- a/aws/services/AWSSupplyChain/SapPrivateLink/SapPrivateLinkNoHostedZone.yaml
+++ b/aws/services/AWSSupplyChain/SapPrivateLink/SapPrivateLinkNoHostedZone.yaml
@@ -16,12 +16,14 @@ Metadata:
           default: SAP Configuration
         Parameters:
           - IP
+          - Protocol
           - Port
+          - HealthCheckPath
           - InVpc
 Parameters:
   DomainName:
     Type: String
-    Description: The fully qualified domain name of DNS
+    Description: The fully qualified or wildcard domain name of DNS
   VpcId:
     Type: AWS::EC2::VPC::Id
     Description: VpcId of your existing Virtual Private Cloud (VPC) where SAP resides
@@ -31,10 +33,21 @@ Parameters:
   IP:
     Type: String
     Description: SAP Gateway's private IP address within VPC
+  Protocol:
+    Type: String
+    AllowedValues:
+      - "HTTP"
+      - "HTTPS"
+    Default: "HTTP"
+    Description: SAP Gateway's connect protocol
   Port:
     Type: Number
     Default: 50000
-    Description: SAP Gateway's HTTP/HTTPS port number
+    Description: SAP Gateway's HTTP or HTTPS (match with protocol you choose above) port number
+  HealthCheckPath:
+    Type: String
+    Default: /sap/public/ping
+    Description: SAP Gateway's ping path to do health check
   InVpc:
     Type: String
     AllowedValues:
@@ -44,6 +57,7 @@ Parameters:
     Description: Choose Yes if SAP resides in above VPC; choose No otherwise (in cases of above VPC just peers with another SAP residing VPC)
 Conditions:
   IpInVpc: !Equals [!Ref InVpc, "Yes"]
+  SapUseHttps: !Equals [!Ref Protocol, "HTTPS"]
 Rules:
   SubnetsInVPC:
     Assertions:
@@ -53,10 +67,14 @@ Rules:
             - Ref: VpcId
         AssertDescription: All subnets must in the VPC
 Resources:
+  ASCPrivateLinkCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Ref DomainName
+      ValidationMethod: DNS
   ASCPrivateLinkLambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: ASCPrivateLinkLambdaRole
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -80,11 +98,11 @@ Resources:
                   - ec2:DescribeVpcEndpointServiceConfigurations
                   - ec2:ModifyVpcEndpointServiceConfiguration
                 Resource: "*"
+    DependsOn: ASCPrivateLinkCertificate
   ASCPrivateLinkLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
       Description: Lambda function to help with private link infrastructure setup
-      FunctionName: ASCPrivateLinkLambdaFunction
       Handler: index.handler
       Role: !GetAtt ASCPrivateLinkLambdaRole.Arn
       Timeout: 900
@@ -128,11 +146,6 @@ Resources:
       ServiceId: !Ref ASCPrivateLinkVPCES
       DomainName: !Ref DomainName
     DependsOn: ASCPrivateLinkVPCES
-  ASCPrivateLinkCertificate:
-    Type: AWS::CertificateManager::Certificate
-    Properties:
-      DomainName: !Ref DomainName
-      ValidationMethod: DNS
   ASCPrivateLinkNLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -142,19 +155,21 @@ Resources:
       LoadBalancerAttributes:
         - Key: load_balancing.cross_zone.enabled # SAP may only live in one AZ, need route to it if traffic from different AZ
           Value: true
+    DependsOn: ASCPrivateLinkCertificate
   ASCPrivateLinkTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       VpcId: !Ref VpcId
-      Protocol: TCP  # use TCP and HTTP for health check as already TLS-terminated and traffic in local network
-      Port: !Ref Port
+      Protocol: !If [SapUseHttps, "TLS", "TCP"]
+      Port: 443
       TargetType: ip
       Targets:
         - AvailabilityZone: !If [IpInVpc, !Ref AWS::NoValue, "all"]
           Id: !Ref IP
           Port: !Ref Port
-      HealthCheckPath: /sap/public/ping
-      HealthCheckProtocol: HTTP
+      HealthCheckPath: !Ref HealthCheckPath
+      HealthCheckProtocol: !Ref Protocol
+    DependsOn: ASCPrivateLinkCertificate
   ASCPrivateLinkListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:


### PR DESCRIPTION
- Fix to always use 443 as targetGroup port that align with NLB listener
- Add support wildcard domain name
- Support concurrent duplicate stack creation and deletion
- Let customer specify protocol to connect to SAP from NLB to SAP (either HTTP or HTTPS) instead of always HTTP
- Enhance the README and input paramter decriptions to better guide customers