### PR TITLE
AmazonCloudWatchAgent: Easy Install is deprecated, changed to pip3 instead

### DIFF
--- a/aws/solutions/AmazonCloudWatchAgent/inline/centos.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/centos.template
@@ -132,9 +132,9 @@ Resources:
            #!/bin/bash
            rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/centos/amd64/latest/amazon-cloudwatch-agent.rpm
            yum update -y
-           easy_install --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+           pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+           cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+           cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:
         Count: 1

--- a/aws/solutions/AmazonCloudWatchAgent/inline/debian.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/debian.template
@@ -134,9 +134,9 @@ Resources:
            dpkg -i /tmp/amazon-cloudwatch-agent.deb
            apt-get update -y
            apt-get  install -y python-pip
-           easy_install --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+           pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+           cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+           cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:
         Count: 1

--- a/aws/solutions/AmazonCloudWatchAgent/inline/debian.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/debian.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWatchAgent on debian. It was validated on debian 8'
+Description: 'Template to install CloudWatchAgent on debian. It was validated on debian 12.0'
 Parameters:
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
@@ -133,8 +133,8 @@ Resources:
            wget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/amazon-cloudwatch-agent.deb
            dpkg -i /tmp/amazon-cloudwatch-agent.deb
            apt-get update -y
-           apt-get  install -y python-pip
-           pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+           apt-get install -y python3 pipx && pipx ensurepath
+           pipx install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
            cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
            cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
     CreationPolicy:

--- a/aws/solutions/AmazonCloudWatchAgent/inline/redhat.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/redhat.template
@@ -132,9 +132,9 @@ Resources:
            #!/bin/bash
            rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
            yum update -y
-           easy_install --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+           pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+           cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+           cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:
         Count: 1

--- a/aws/solutions/AmazonCloudWatchAgent/inline/suse.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/suse.template
@@ -132,9 +132,9 @@ Resources:
            #!/bin/bash
            rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/suse/amd64/latest/amazon-cloudwatch-agent.rpm
            yum update -y
-           easy_install --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+           pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+           cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+           cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:
         Count: 1

--- a/aws/solutions/AmazonCloudWatchAgent/inline/ubuntu.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/ubuntu.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWatchAgent on ubuntu. It was validated on ubuntu 16'
+Description: 'Template to install CloudWatchAgent on ubuntu. It was validated on ubuntu 22.04'
 Parameters:
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
@@ -133,7 +133,7 @@ Resources:
            wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/amazon-cloudwatch-agent.deb
            dpkg -i /tmp/amazon-cloudwatch-agent.deb
            apt-get update -y
-           apt-get  install -y python-pip
+           apt-get install -y python3 python3-pip
            pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
            cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
            cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}

--- a/aws/solutions/AmazonCloudWatchAgent/inline/ubuntu.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/ubuntu.template
@@ -134,9 +134,9 @@ Resources:
            dpkg -i /tmp/amazon-cloudwatch-agent.deb
            apt-get update -y
            apt-get  install -y python-pip
-           easy_install --script-dir /opt/aws/bin  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+           pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+           cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+           cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:
         Count: 1

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/centos.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/centos.template
@@ -123,9 +123,9 @@ Resources:
                rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/centos/amd64/latest/amazon-cloudwatch-agent.rpm
                /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s
                yum update -y
-               easy_install --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-               /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-               /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+               pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+               cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+               cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
             - { ssmkey: !Ref SSMKey }
     CreationPolicy:
       ResourceSignal:

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/debian.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/debian.template
@@ -125,9 +125,9 @@ Resources:
                /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s
                apt-get update -y
                apt-get  install -y python-pip
-               easy_install --script-dir /opt/aws/bin  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-               /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-               /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+               pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+               cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+               cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
             - { ssmkey: !Ref SSMKey }
     CreationPolicy:
       ResourceSignal:

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/debian.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/debian.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWatchAgent on debian. It was validated on debian 8'
+Description: 'Template to install CloudWatchAgent on debian. It was validated on debian 12.0'
 Parameters:
   SSMKey :
     Description: Name of parameter store which contains the json configuration of CWAgent.
@@ -124,8 +124,8 @@ Resources:
                dpkg -i /tmp/amazon-cloudwatch-agent.deb
                /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s
                apt-get update -y
-               apt-get  install -y python-pip
-               pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+               apt-get install -y python3 pipx && pipx ensurepath
+               pipx install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
                cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
                cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
             - { ssmkey: !Ref SSMKey }

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/redhat.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/redhat.template
@@ -123,9 +123,9 @@ Resources:
                rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
                /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s
                yum update -y
-               easy_install --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-               /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-               /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+               pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+               cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+               cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
             - { ssmkey: !Ref SSMKey }
     CreationPolicy:
       ResourceSignal:

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/suse.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/suse.template
@@ -123,9 +123,9 @@ Resources:
                rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/suse/amd64/latest/amazon-cloudwatch-agent.rpm
                /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s
                yum update -y
-               easy_install --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-               /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-               /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+               pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+               cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+               cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
             - { ssmkey: !Ref SSMKey }
     CreationPolicy:
       ResourceSignal:

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/ubuntu.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/ubuntu.template
@@ -125,9 +125,9 @@ Resources:
                /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s
                apt-get update -y
                apt-get  install -y python-pip
-               easy_install --script-dir /opt/aws/bin  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-               /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-               /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+               pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+               cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+               cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
             - { ssmkey: !Ref SSMKey }
     CreationPolicy:
       ResourceSignal:

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/ubuntu.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/ubuntu.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to install CloudWatchAgent on ubuntu. It was validated on ubuntu 16'
+Description: 'Template to install CloudWatchAgent on ubuntu. It was validated on ubuntu 22.04'
 Parameters:
   SSMKey :
     Description: Name of parameter store which contains the json configuration of CWAgent.
@@ -124,7 +124,7 @@ Resources:
                dpkg -i /tmp/amazon-cloudwatch-agent.deb
                /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s
                apt-get update -y
-               apt-get  install -y python-pip
+               apt-get install -y python3 python3-pip
                pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
                cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
                cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}


### PR DESCRIPTION
Current version of templates for the CloudWatch Agent is outdated. Since easy_install is [deprecated ](https://setuptools.pypa.io/en/latest/history.html#v42-0-0), I have changed templates to use pip3 instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
