### PR TITLE
Add 6 additional DynamoDB tables with Point-in-Time Recovery configuration

### DIFF
--- a/DynamoDB/DynamoDB_Table.yaml
+++ b/DynamoDB/DynamoDB_Table.yaml
@@ -55,7 +55,121 @@ Resources:
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
 
+  myDynamoDBTable1:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: !Ref HashKeyElementName
+          AttributeType: !Ref HashKeyElementType
+      KeySchema:
+        - AttributeName: !Ref HashKeyElementName
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: !Ref ReadCapacityUnits
+        WriteCapacityUnits: !Ref WriteCapacityUnits
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+
+  myDynamoDBTable2:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: !Ref HashKeyElementName
+          AttributeType: !Ref HashKeyElementType
+      KeySchema:
+        - AttributeName: !Ref HashKeyElementName
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: !Ref ReadCapacityUnits
+        WriteCapacityUnits: !Ref WriteCapacityUnits
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+
+  myDynamoDBTable3:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: !Ref HashKeyElementName
+          AttributeType: !Ref HashKeyElementType
+      KeySchema:
+        - AttributeName: !Ref HashKeyElementName
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: !Ref ReadCapacityUnits
+        WriteCapacityUnits: !Ref WriteCapacityUnits
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+
+  myDynamoDBTable4:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: !Ref HashKeyElementName
+          AttributeType: !Ref HashKeyElementType
+      KeySchema:
+        - AttributeName: !Ref HashKeyElementName
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: !Ref ReadCapacityUnits
+        WriteCapacityUnits: !Ref WriteCapacityUnits
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: false
+
+  myDynamoDBTable5:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: !Ref HashKeyElementName
+          AttributeType: !Ref HashKeyElementType
+      KeySchema:
+        - AttributeName: !Ref HashKeyElementName
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: !Ref ReadCapacityUnits
+        WriteCapacityUnits: !Ref WriteCapacityUnits
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: false
+
+  myDynamoDBTable6:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: !Ref HashKeyElementName
+          AttributeType: !Ref HashKeyElementType
+      KeySchema:
+        - AttributeName: !Ref HashKeyElementName
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: !Ref ReadCapacityUnits
+        WriteCapacityUnits: !Ref WriteCapacityUnits
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: false
+
 Outputs:
   TableName:
     Description: Table name of the newly created DynamoDB table
     Value: !Ref myDynamoDBTable
+
+  TableName1:
+    Description: Table name of the first additional DynamoDB table
+    Value: !Ref myDynamoDBTable1
+
+  TableName2:
+    Description: Table name of the second additional DynamoDB table
+    Value: !Ref myDynamoDBTable2
+
+  TableName3:
+    Description: Table name of the third additional DynamoDB table
+    Value: !Ref myDynamoDBTable3
+
+  TableName4:
+    Description: Table name of the fourth additional DynamoDB table
+    Value: !Ref myDynamoDBTable4
+
+  TableName5:
+    Description: Table name of the fifth additional DynamoDB table
+    Value: !Ref myDynamoDBTable5
+
+  TableName6:
+    Description: Table name of the sixth additional DynamoDB table
+    Value: !Ref myDynamoDBTable6


### PR DESCRIPTION
## Description
This pull request adds 6 additional DynamoDB tables to the existing DynamoDB_Table.yaml CloudFormation template.

## Changes Made
- Added 6 new DynamoDB table resources:
  - `myDynamoDBTable1` - Point-in-Time Recovery enabled
  - `myDynamoDBTable2` - Point-in-Time Recovery enabled  
  - `myDynamoDBTable3` - Point-in-Time Recovery enabled
  - `myDynamoDBTable4` - Point-in-Time Recovery disabled
  - `myDynamoDBTable5` - Point-in-Time Recovery disabled
  - `myDynamoDBTable6` - Point-in-Time Recovery disabled

## Configuration Details
- First 3 tables have Point-in-Time Recovery enabled (true)
- Last 3 tables have Point-in-Time Recovery disabled (false)
- All tables maintain the same parameter structure as the original table
- Added corresponding outputs for all new tables

## Testing
The template structure follows the existing pattern and should deploy successfully with the same parameters as the original template.

---
*Note: This PR will be closed shortly for demonstration purposes.*