### PR TITLE
Feature/al2023 wordpress

### DIFF
--- a/Solutions/WordPress/README.md
+++ b/Solutions/WordPress/README.md
@@ -1,0 +1,22 @@
+# WordPress Multi-AZ AL2023
+
+## Description
+
+This template installs a highly-available, scalable WordPress deployment using a multi-AZ Amazon RDS database instance for storage, Load balancer, EC2 instance and other required resources. It demonstrates using the AWS CloudFormation bootstrap scripts to deploy WordPress on EC2 with Amazon Linux 2023 AMI with PHP 8 and Apache 2.4.
+
+It has been tested in Mumbai (ap-south-1) region with EC2 t4g.micro and RDS db.t4g.micro instances. It shows its compatible with AL2023 AMI and ARM64 architecture.
+
+
+## Instructions
+
+Follow these simple steps to deploy WordPress site using WordPress_Multi_AZ_AL2023.yaml.
+
+1) Login to your AWS account, go to CloudFormation and create a new stack by uploading WordPress_Multi_AZ_AL2023.template.
+   
+2) Select the options for your stack.
+
+3) Wait for the stack to be created. You will find load balancer URL in the Outputs tab. Open that URL to start WordPress installation.
+
+4) Once the WordPress is installed, you can login to WordPress admin panel.
+
+5) You can verify the Apache and PHP versions by logging into server using SSH.

--- a/Solutions/WordPress/README.md
+++ b/Solutions/WordPress/README.md
@@ -2,16 +2,16 @@
 
 ## Description
 
-This template installs a highly-available, scalable WordPress deployment using a multi-AZ Amazon RDS database instance for storage, Load balancer, EC2 instance and other required resources. It demonstrates using the AWS CloudFormation bootstrap scripts to deploy WordPress on EC2 with Amazon Linux 2023 AMI with PHP 8 and Apache 2.4.
+This template installs a highly-available, scalable WordPress deployment using a multi-AZ Amazon RDS database instance for storage, Load balancer, EC2 instance and other required resources. It demonstrates using the AWS CloudFormation bootstrap scripts to deploy WordPress on EC2 with Amazon Linux 2023 AMI, PHP 8 and Apache 2.4.
 
-It has been tested in Mumbai (ap-south-1) region with EC2 t4g.micro and RDS db.t4g.micro instances. It shows its compatible with AL2023 AMI and ARM64 architecture.
+It has been tested in Mumbai (ap-south-1) region with t4g.micro EC2 instance and db.t4g.micro RDS instance. It shows its compatible with AL2023 AMI and ARM64 architecture.
 
 
 ## Instructions
 
 Follow these simple steps to deploy WordPress site using WordPress_Multi_AZ_AL2023.yaml.
 
-1) Login to your AWS account, go to CloudFormation and create a new stack by uploading WordPress_Multi_AZ_AL2023.template.
+1) Login to your AWS account, go to CloudFormation and create a new stack by uploading WordPress_Multi_AZ_AL2023.yaml.
    
 2) Select the options for your stack.
 

--- a/Solutions/WordPress/WordPress_Multi_AZ_AL2023.yaml
+++ b/Solutions/WordPress/WordPress_Multi_AZ_AL2023.yaml
@@ -1,0 +1,365 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  AWS CloudFormation Sample Template WordPress_Multi_AZ_AL2023: This template installs a highly-available, scalable WordPress deployment using a multi-AZ Amazon RDS database instance for storage, Load balancer, EC2 instance and other required resources. It demonstrates using the AWS CloudFormation bootstrap scripts to deploy WordPress on EC2 with Amazon Linux 2023 AMI.ls **WARNING** This template creates an Amazon EC2 instance, an Application Load Balancer and an Amazon RDS database instance. You will be billed for the AWS resources used if you create a stack from this template.
+Parameters:
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VpcId of your existing Virtual Private Cloud (VPC)
+    ConstraintDescription: must be the VPC Id of an existing Virtual Private Cloud.
+  Subnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: The list of SubnetIds in your Virtual Private Cloud (VPC)
+    ConstraintDescription: must be a list of at least two existing subnets associated with at least two different availability zones. They should be residing in the selected Virtual Private Cloud.
+  KeyName:
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instances
+    Type: AWS::EC2::KeyPair::KeyName
+    ConstraintDescription: must be the name of an existing EC2 KeyPair.
+  InstanceType:
+    Description: WebServer EC2 instance type
+    Type: String
+    Default: t4g.micro
+    AllowedValues:
+      - t4g.medium
+      - t4g.small
+      - t4g.micro
+    ConstraintDescription: must be a valid EC2 instance type.
+  SSHLocation:
+    Description: The IP address range that can be used to SSH to the EC2 instances
+    Type: String
+    MinLength: '9'
+    MaxLength: '18'
+    Default: 110.227.239.171/32
+    AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
+    ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
+  DBClass:
+    Description: Database instance class
+    Type: String
+    Default: db.t4g.micro
+    AllowedValues:
+      - db.t4g.micro
+      - db.t4g.small
+      - db.t4g.medium
+      - db.t1.micro
+      - db.m1.small
+      - db.m1.medium
+      - db.m1.large
+      - db.m1.xlarge
+      - db.m2.xlarge
+      - db.m2.2xlarge
+      - db.m2.4xlarge
+      - db.m3.medium
+      - db.m3.large
+      - db.m3.xlarge
+      - db.m3.2xlarge
+      - db.m4.large
+      - db.m4.xlarge
+      - db.m4.2xlarge
+      - db.m4.4xlarge
+      - db.m4.10xlarge
+      - db.r3.large
+      - db.r3.xlarge
+      - db.r3.2xlarge
+      - db.r3.4xlarge
+      - db.r3.8xlarge
+      - db.m2.xlarge
+      - db.m2.2xlarge
+      - db.m2.4xlarge
+      - db.cr1.8xlarge
+      - db.t2.micro
+      - db.t2.small
+      - db.t2.medium
+      - db.t2.large
+    ConstraintDescription: must select a valid database instance type.
+  DBName:
+    Default: wordpressdb
+    Description: The WordPress database name
+    Type: String
+    MinLength: '1'
+    MaxLength: '64'
+    AllowedPattern: '[a-zA-Z][a-zA-Z0-9]*'
+    ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
+  DBUser:
+    NoEcho: 'true'
+    Description: The WordPress database admin account username
+    Type: String
+    MinLength: '1'
+    MaxLength: '16'
+    AllowedPattern: '[a-zA-Z][a-zA-Z0-9]*'
+    ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
+  DBPassword:
+    NoEcho: 'true'
+    Description: The WordPress database admin account password
+    Type: String
+    MinLength: '8'
+    MaxLength: '41'
+    AllowedPattern: '[a-zA-Z0-9]*'
+    ConstraintDescription: must contain only alphanumeric characters.
+  MultiAZDatabase:
+    Default: 'false'
+    Description: Create a Multi-AZ MySQL Amazon RDS database instance
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    ConstraintDescription: must be either true or false.
+  WebServerCapacity:
+    Default: '1'
+    Description: The initial number of WebServer instances
+    Type: Number
+    MinValue: '1'
+    MaxValue: '5'
+    ConstraintDescription: must be between 1 and 5 EC2 instances.
+  DBAllocatedStorage:
+    Default: '5'
+    Description: The size of the database (Gb)
+    Type: Number
+    MinValue: '5'
+    MaxValue: '1024'
+    ConstraintDescription: must be between 5 and 1024Gb.
+Resources:
+  ApplicationLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      SecurityGroups:
+        - !Ref 'ALBSecurityGroup'
+      Subnets: !Ref 'Subnets'
+  ALBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow http in ingress to the ALB, and to the web server security group in egress.
+      VpcId: !Ref 'VpcId'
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: '0.0.0.0/0'
+  ALBSecurityGroupEgressRule:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      DestinationSecurityGroupId: !GetAtt 'WebServerSecurityGroup.GroupId'
+      GroupId: !GetAtt 'ALBSecurityGroup.GroupId'
+  ALBListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref 'ALBTargetGroup'
+      LoadBalancerArn: !Ref 'ApplicationLoadBalancer'
+      Port: '80'
+      Protocol: HTTP
+  ALBTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckPath: /wordpress/wp-admin/install.php
+      HealthCheckIntervalSeconds: 10
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      Port: 80
+      Protocol: HTTP
+      UnhealthyThresholdCount: 5
+      VpcId: !Ref 'VpcId'
+      TargetGroupAttributes:
+        - Key: stickiness.enabled
+          Value: 'true'
+        - Key: stickiness.type
+          Value: lb_cookie
+        - Key: stickiness.lb_cookie.duration_seconds
+          Value: '30'
+  WebServerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enable HTTP access via port 80 locked down to the load balancer + SSH access
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: '80'
+          ToPort: '80'
+          SourceSecurityGroupId: !Select
+            - 0
+            - !GetAtt 'ApplicationLoadBalancer.SecurityGroups'
+        - IpProtocol: tcp
+          FromPort: '22'
+          ToPort: '22'
+          CidrIp: !Ref 'SSHLocation'
+      VpcId: !Ref 'VpcId'
+  WebServerGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    DependsOn:
+      - DBInstance
+    Properties:
+      VPCZoneIdentifier: !Ref 'Subnets'
+      MinSize: '1'
+      MaxSize: '5'
+      DesiredCapacity: !Ref 'WebServerCapacity'
+      TargetGroupARNs:
+        - !Ref 'ALBTargetGroup'
+      LaunchTemplate:
+        LaunchTemplateId: !Ref 'WebLaunchTemplate'
+        Version: !GetAtt 'WebLaunchTemplate.LatestVersionNumber'
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT15M
+        Count: 1
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MinInstancesInService: '1'
+        MaxBatchSize: '1'
+        PauseTime: PT15M
+        WaitOnResourceSignals: 'true'
+        MinSuccessfulInstancesPercent: 50
+  WebLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Metadata:
+      AWS::CloudFormation::Init:
+        configSets:
+          wordpress_install:
+            - install_cfn
+            - install_wordpress
+        install_cfn:
+          files:
+            /etc/cfn/cfn-hup.conf:
+              content: !Join
+                - ''
+                - - "[main]\n"
+                  - stack=
+                  - !Ref 'AWS::StackId'
+                  - "\n"
+                  - region=
+                  - !Ref 'AWS::Region'
+                  - "\n"
+              mode: '000400'
+              owner: root
+              group: root
+            /etc/cfn/hooks.d/cfn-auto-reloader.conf:
+              content: !Join
+                - ''
+                - - "[cfn-auto-reloader-hook]\n"
+                  - "triggers=post.update\n"
+                  - "path=Resources.WebLaunchTemplate.Metadata.AWS::CloudFormation::Init\n"
+                  - 'action=/opt/aws/bin/cfn-init -v '
+                  - ' --stack '
+                  - !Ref 'AWS::StackName'
+                  - ' --resource WebLaunchTemplate '
+                  - ' --configsets wordpress_install '
+                  - ' --region '
+                  - !Ref 'AWS::Region'
+                  - "\n"
+              mode: '000400'
+              owner: root
+              group: root
+          services:
+            systemd:
+              cfn-hup:
+                enabled: true
+                ensureRunning: true
+                files:
+                  - /etc/cfn/cfn-hup.conf
+                  - /etc/cfn/hooks.d/cfn-auto-reloader.conf
+        install_wordpress:
+          commands:
+            '01_update_os':
+              command: dnf update -y --security || true
+            '02_install_web_stack':
+              command: dnf install -y httpd php php-mysqlnd mariadb105
+            '03_enable_httpd':
+              command: systemctl enable httpd && systemctl start httpd
+            '04_create_wp_config':
+              command: /tmp/create-wp-config
+          sources:
+            /var/www/html: http://wordpress.org/latest.tar.gz
+          files:
+            /tmp/create-wp-config:
+              content: !Join
+                - "\n"
+                - - '#!/bin/bash'
+                  - set -e
+                  - ''
+                  - WP_DIR=/var/www/html/wordpress
+                  - ''
+                  - for i in {1..15}; do
+                  - '  if [ -f "$WP_DIR/wp-config-sample.php" ]; then'
+                  - '    break'
+                  - '  fi'
+                  - '  sleep 2'
+                  - done
+                  - ''
+                  - if [ ! -f "$WP_DIR/wp-config-sample.php" ]; then
+                  - '  echo "WordPress not found" >&2'
+                  - '  exit 1'
+                  - fi
+                  - ''
+                  - cp "$WP_DIR/wp-config-sample.php" "$WP_DIR/wp-config.php"
+                  - !Sub 'sed -i "s/''database_name_here''/''${DBName}''/g" "$WP_DIR/wp-config.php"'
+                  - !Sub 'sed -i "s/''username_here''/''${DBUser}''/g" "$WP_DIR/wp-config.php"'
+                  - !Sub 'sed -i "s/''password_here''/''${DBPassword}''/g" "$WP_DIR/wp-config.php"'
+                  - !Sub 'sed -i "s/''localhost''/''${DBInstance.Endpoint.Address}''/g" "$WP_DIR/wp-config.php"'
+                  - ''
+                  - chown apache:apache "$WP_DIR/wp-config.php"
+                  - chmod 640 "$WP_DIR/wp-config.php"
+              mode: '000500'
+              owner: root
+              group: root
+    Properties:
+      LaunchTemplateData:
+        ImageId: !Sub '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64}}'
+        InstanceType: !Ref 'InstanceType'
+        SecurityGroupIds:
+          - !Ref 'WebServerSecurityGroup'
+        KeyName: !Ref 'KeyName'
+        UserData: !Base64
+          Fn::Join:
+            - ''
+            - - "#!/bin/bash\n"
+              - "set -e\n"
+              - "set -o pipefail\n"
+              - "dnf install -y aws-cfn-bootstrap\n"
+              - '/opt/aws/bin/cfn-init -v '
+              - ' --stack '
+              - !Ref 'AWS::StackName'
+              - ' --resource WebLaunchTemplate '
+              - ' --configsets wordpress_install '
+              - ' --region '
+              - !Ref 'AWS::Region'
+              - "\n"
+              - "CFN_EXIT_CODE=$?\n"
+              - '/opt/aws/bin/cfn-signal '
+              - ' --exit-code ${CFN_EXIT_CODE} '
+              - ' --stack '
+              - !Ref 'AWS::StackName'
+              - ' --resource WebServerGroup '
+              - ' --region '
+              - !Ref 'AWS::Region'
+              - "\n"
+              - "exit ${CFN_EXIT_CODE}\n"
+  DBEC2SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Open database for access
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: '3306'
+          ToPort: '3306'
+          SourceSecurityGroupId: !Ref 'WebServerSecurityGroup'
+      VpcId: !Ref 'VpcId'
+  DBInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBName: !Ref 'DBName'
+      Engine: MySQL
+      MultiAZ: !Ref 'MultiAZDatabase'
+      MasterUsername: !Ref 'DBUser'
+      MasterUserPassword: !Ref 'DBPassword'
+      DBInstanceClass: !Ref 'DBClass'
+      AllocatedStorage: !Ref 'DBAllocatedStorage'
+      VPCSecurityGroups:
+        - !GetAtt 'DBEC2SecurityGroup.GroupId'
+Outputs:
+  WebsiteURL:
+    Value: !Join
+      - ''
+      - - http://
+        - !GetAtt 'ApplicationLoadBalancer.DNSName'
+        - /wordpress
+    Description: WordPress Website

--- a/Solutions/WordPress/WordPress_Multi_AZ_AL2023.yaml
+++ b/Solutions/WordPress/WordPress_Multi_AZ_AL2023.yaml
@@ -28,7 +28,7 @@ Parameters:
     Type: String
     MinLength: '9'
     MaxLength: '18'
-    Default: 110.227.239.171/32
+    Default: 192.0.2.0/24
     AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
     ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
   DBClass:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds a new Amazon Linux 2023 (AL2023) compatible CloudFormation template for deploying WordPress in a highly available, Multi-AZ architecture using:
- Application Load Balancer
- Auto Scaling Group
- Amazon RDS (MySQL)
- CloudFormation Init & Signals

The existing WordPress templates provided in official AWS documentation are based on Amazon Linux 2, which is no longer suitable for new deployments due to differences in package management, service handling, and AMI lifecycle. This PR provides a modernized, production-ready alternative that works out-of-the-box on AL2023.

This template has been run multiple times and stack creates the resouces successfully. When stack is deleted, all resouces are deleted correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
